### PR TITLE
Remove input isBlank check

### DIFF
--- a/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/editor/EditorRoute.kt
+++ b/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/editor/EditorRoute.kt
@@ -26,7 +26,7 @@ private val outputSessions: Cache<String, String> =
 public fun Route.installEditor() {
     post(URL_EDITOR_INPUT) {
         val input = Serializers.json.tryDecodeFromString<EditorInput>(call.receiveText())
-        if (input == null || input.input.isBlank()) {
+        if (input == null) {
             call.response.status(HttpStatusCode.BadRequest)
         } else {
             generateToken().let { token ->


### PR DESCRIPTION
Checking for a malformed or incomplete (including empty) request body is already done by the `tryDecodeFromString` method

This change allows for using the editor API to create a new message (with its {token} command generation features), rather than edit an already existing one