### PR TITLE
Preserve newline characters as single newline characters

### DIFF
--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -94,7 +94,7 @@ public fun main() {
                     if (isInEditorMode && ::editorInput.isInitialized) {
                         window.fetch(
                                 "$URL_API$URL_EDITOR$URL_EDITOR_OUTPUT",
-                                RequestInit("POST", body = input.value.replace("\n", "\\n")))
+                                RequestInit("POST", body = input.value))
                             .then { response ->
                                 response.text().then { token ->
                                     window.navigator.clipboard.writeText(


### PR DESCRIPTION
Minimessage (no longer?) doesn't convert the escape sequence `\n` to a newline, so escaping the newlines doesn't make much sense.
From the point of this request onwards, all requests bodies are in pure plaintext, so no escaping will be lost
Currently, an user of the API will receive a string with escaped newlines and will need to convert them for example with `.replace("\\n", "\n")` to get an output comparable to what is shown on the website preview