### PR TITLE
Allow input box to be resized taller than 4 rows

### DIFF
--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -86,7 +86,7 @@
           <!-- INPUT -->
           <div class="column is-full mt-1 pb-0">
             <label for="input">Input: </label>
-            <textarea id="input" class="textarea has-fixed-size mono-font" rows="4" placeholder="<blue>Hello <red>World!" spellcheck="false"></textarea>
+            <textarea id="input" class="textarea mono-font" minrows="4" placeholder="<blue>Hello <red>World!" spellcheck="false"></textarea>
           </div>
         </div>
 


### PR DESCRIPTION
Removes `has-fixed-size` from input box. Bulma already seems to already make textareas be `resize: vertical` only by default, so the input and output will still match in width.

This does result in some visual jank with the background image but at least it's functional?