### PR TITLE
Show text hover events

### DIFF
--- a/src/commonMain/kotlin/net/kyori/adventure/webui/Constants.kt
+++ b/src/commonMain/kotlin/net/kyori/adventure/webui/Constants.kt
@@ -3,9 +3,6 @@ package net.kyori.adventure.webui
 /** Class for DOM-rendered Adventure components. */
 public const val COMPONENT_CLASS: String = "adventure-component"
 
-/** ID for the single hover tooltip element. */
-public const val HOVER_TOOLTIP_ID: String = "hover-tooltip"
-
 /** Data name for insertion value. */
 public val DATA_INSERTION: DataAttribute = DataAttribute("insertion")
 

--- a/src/commonMain/kotlin/net/kyori/adventure/webui/Constants.kt
+++ b/src/commonMain/kotlin/net/kyori/adventure/webui/Constants.kt
@@ -6,11 +6,8 @@ public const val COMPONENT_CLASS: String = "adventure-component"
 /** Data name for insertion value. */
 public val DATA_INSERTION: DataAttribute = DataAttribute("insertion")
 
-/** Data name for hover event actions. */
-public val DATA_HOVER_EVENT_ACTION: DataAttribute = DataAttribute("hover-event-action")
-
-/** Data name for hover event values. */
-public val DATA_HOVER_EVENT_VALUE: DataAttribute = DataAttribute("hover-event-value")
+/** Data name for "show text" hover event values. */
+public val DATA_HOVER_EVENT_SHOW_TEXT: DataAttribute = DataAttribute("hover-event-show-text")
 
 /** Data name for click event actions. */
 public val DATA_CLICK_EVENT_ACTION: DataAttribute = DataAttribute("click-event-action")

--- a/src/commonMain/kotlin/net/kyori/adventure/webui/Constants.kt
+++ b/src/commonMain/kotlin/net/kyori/adventure/webui/Constants.kt
@@ -3,6 +3,9 @@ package net.kyori.adventure.webui
 /** Class for DOM-rendered Adventure components. */
 public const val COMPONENT_CLASS: String = "adventure-component"
 
+/** ID for the single hover tooltip element. */
+public const val HOVER_TOOLTIP_ID: String = "hover-tooltip"
+
 /** Data name for insertion value. */
 public val DATA_INSERTION: DataAttribute = DataAttribute("insertion")
 

--- a/src/commonMain/resources/web/css/style.css
+++ b/src/commonMain/resources/web/css/style.css
@@ -168,11 +168,13 @@
     padding: 0;
 }
 #output-pre.mode-lore {
+    display: inline-flex;
+    flex-direction: column;
+}
+output-pre.mode-lore, #hover-tooltip {
     background-color: rgba(1, 1, 1, 0.8);
     border: solid #1b0035;
-    display: inline-flex;
     padding: 5px;
-    flex-direction: column;
     line-height: 19px;
     border-radius: 5px;
 }
@@ -191,7 +193,6 @@
     font-size: 20px;
     line-height: 20px;
 }
-/* hover tooltip (style removed) */
 #hover-tooltip {
     position: fixed;
     top: 0;

--- a/src/commonMain/resources/web/css/style.css
+++ b/src/commonMain/resources/web/css/style.css
@@ -114,13 +114,13 @@
     display: block;
 }
 /* output pre */
-#output-pre {
+#output-pre, #hover-tooltip {
     margin-bottom: 4px;
     color: white;
     background-color: rgba(1, 1, 1, 0.4);
     text-shadow: 3px 3px hsl(0, 0%, 24%);
 }
-#output-pre span {
+#output-pre span, #hover-tooltip span {
     font-size: 28px;
     line-height: 28px;
 }
@@ -190,6 +190,14 @@
 #output-pre.mode-server-list span {
     font-size: 20px;
     line-height: 20px;
+}
+/* hover tooltip (style removed) */
+#hover-tooltip {
+    position: fixed;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+    z-index: 9999;
 }
 /* other shit */
 .is-horizontal {

--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -92,6 +92,7 @@
 
         <div class="columns output-column is-flex-grow-1 is-flex-shrink-0">
           <!-- OUTPUT -->
+          <div hidden id="hover-tooltip" class="mc-font"></div>
           <div class="column is-full is-flex is-flex-direction-column">
             <label for="output-pane">Output: </label>
             <div id="output-pane" class="is-flex-grow-1 is-flex-shrink-0">

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -301,12 +301,9 @@ public fun main() {
                 "mouseover",
                 { event ->
                     val target = event.target
-                    if (target is HTMLSpanElement && target.classList.contains(COMPONENT_CLASS)) {
-                        checkHoverEvents(target, hoverTooltip)
-
-                        // we need to prevent propagation as we do that ourselves manually
-                        event.stopPropagation()
-                    }
+                    checkHoverEvents(target, hoverTooltip)
+                    // we need to prevent propagation as we do that ourselves manually
+                    event.stopPropagation()
                 })
 
             document.addEventListener(
@@ -318,8 +315,6 @@ public fun main() {
                             hoverTooltip.hidden = true
                             hoverTooltip.innerHTML = ""
                         }
-
-                        // we need to prevent propagation as we do that ourselves manually
                         event.stopPropagation()
                     }
                 })
@@ -415,13 +410,18 @@ private fun onWebsocketReady() {
         }
 }
 
-private fun checkHoverEvents(target: HTMLSpanElement, hoverTooltip: HTMLDivElement) {
-    if (EventType.HOVER.isUsable(currentMode)) {
-        val hoverAction = target.dataset[DATA_HOVER_EVENT_ACTION.camel]
-        if (hoverAction == "show_text") {
-            hoverTooltip.hidden = false
-            hoverTooltip.innerHTML = target.dataset[DATA_HOVER_EVENT_VALUE.camel] ?: ""
+private fun checkHoverEvents(target: EventTarget?, hoverTooltip: HTMLDivElement) {
+    if (target is HTMLSpanElement && target.classList.contains(COMPONENT_CLASS)) {
+        if (EventType.HOVER.isUsable(currentMode)) {
+            val hoverAction = target.dataset[DATA_HOVER_EVENT_ACTION.camel]
+            if (hoverAction == "show_text") {
+                hoverTooltip.hidden = false
+                hoverTooltip.innerHTML = target.dataset[DATA_HOVER_EVENT_VALUE.camel] ?: ""
+                // No further bubbling required
+                return
+            }
         }
+        checkHoverEvents(target.parentElement, hoverTooltip)
     }
 }
 

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -137,7 +137,7 @@ public fun main() {
             val outputPre = document.getElementById("output-pre")!!.unsafeCast<HTMLPreElement>()
             val outputPane = document.getElementById("output-pane")!!.unsafeCast<HTMLDivElement>()
             val hoverTooltip =
-                document.getElementById(HOVER_TOOLTIP_ID).unsafeCast<HTMLDivElement>()
+                document.getElementById("hover-tooltip").unsafeCast<HTMLDivElement>()
 
             // CARET
             val chatBox = document.getElementById("chat-entry-box")!!.unsafeCast<HTMLDivElement>()

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -136,8 +136,7 @@ public fun main() {
             // OUTPUT BOXES
             val outputPre = document.getElementById("output-pre")!!.unsafeCast<HTMLPreElement>()
             val outputPane = document.getElementById("output-pane")!!.unsafeCast<HTMLDivElement>()
-            val hoverTooltip =
-                document.getElementById("hover-tooltip").unsafeCast<HTMLDivElement>()
+            val hoverTooltip = document.getElementById("hover-tooltip").unsafeCast<HTMLDivElement>()
 
             // CARET
             val chatBox = document.getElementById("chat-entry-box")!!.unsafeCast<HTMLDivElement>()
@@ -413,10 +412,10 @@ private fun onWebsocketReady() {
 private fun checkHoverEvents(target: EventTarget?, hoverTooltip: HTMLDivElement) {
     if (target is HTMLSpanElement && target.classList.contains(COMPONENT_CLASS)) {
         if (EventType.HOVER.isUsable(currentMode)) {
-            val hoverAction = target.dataset[DATA_HOVER_EVENT_ACTION.camel]
-            if (hoverAction == "show_text") {
+            val showTextHover = target.dataset[DATA_HOVER_EVENT_SHOW_TEXT.camel]
+            if (showTextHover != null) {
                 hoverTooltip.hidden = false
-                hoverTooltip.innerHTML = target.dataset[DATA_HOVER_EVENT_VALUE.camel] ?: ""
+                hoverTooltip.innerHTML = showTextHover
                 // No further bubbling required
                 return
             }

--- a/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/hook/StandardRenderHooks.kt
+++ b/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/hook/StandardRenderHooks.kt
@@ -11,12 +11,19 @@ import net.kyori.adventure.webui.DATA_HOVER_EVENT_VALUE
 import net.kyori.adventure.webui.DATA_INSERTION
 import net.kyori.adventure.webui.jvm.addData
 import net.kyori.adventure.webui.jvm.addStyle
+import net.kyori.adventure.webui.jvm.appendComponent
 
 /** A render hook for hover events. */
 public val HOVER_EVENT_RENDER_HOOK: ComponentRenderHook = { component ->
     component.hoverEvent()?.let { hoverEvent ->
         addData(DATA_HOVER_EVENT_ACTION, hoverEvent.action().toString())
-        addData(DATA_HOVER_EVENT_VALUE, hoverEvent.value().toString())
+        if (hoverEvent.value() is TextComponent) {
+            val hoverHtml = StringBuilder()
+            hoverHtml.appendComponent(HookManager.render(hoverEvent.value() as TextComponent))
+            addData(DATA_HOVER_EVENT_VALUE, hoverHtml.toString())
+        } else {
+            addData(DATA_HOVER_EVENT_VALUE, hoverEvent.value().toString())
+        }
     }
 
     true

--- a/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/hook/StandardRenderHooks.kt
+++ b/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/hook/StandardRenderHooks.kt
@@ -1,14 +1,11 @@
 package net.kyori.adventure.webui.jvm.minimessage.hook
 
 import kotlinx.html.classes
+import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
+import net.kyori.adventure.text.event.HoverEvent
 import net.kyori.adventure.text.format.TextDecoration
-import net.kyori.adventure.webui.COMPONENT_CLASS
-import net.kyori.adventure.webui.DATA_CLICK_EVENT_ACTION
-import net.kyori.adventure.webui.DATA_CLICK_EVENT_VALUE
-import net.kyori.adventure.webui.DATA_HOVER_EVENT_ACTION
-import net.kyori.adventure.webui.DATA_HOVER_EVENT_VALUE
-import net.kyori.adventure.webui.DATA_INSERTION
+import net.kyori.adventure.webui.*
 import net.kyori.adventure.webui.jvm.addData
 import net.kyori.adventure.webui.jvm.addStyle
 import net.kyori.adventure.webui.jvm.appendComponent
@@ -16,14 +13,12 @@ import net.kyori.adventure.webui.jvm.appendComponent
 /** A render hook for hover events. */
 public val HOVER_EVENT_RENDER_HOOK: ComponentRenderHook = { component ->
     component.hoverEvent()?.let { hoverEvent ->
-        addData(DATA_HOVER_EVENT_ACTION, hoverEvent.action().toString())
-        if (hoverEvent.value() is TextComponent) {
+        if (hoverEvent.action() == HoverEvent.Action.SHOW_TEXT) {
             val hoverHtml = StringBuilder()
-            hoverHtml.appendComponent(HookManager.render(hoverEvent.value() as TextComponent))
-            addData(DATA_HOVER_EVENT_VALUE, hoverHtml.toString())
-        } else {
-            addData(DATA_HOVER_EVENT_VALUE, hoverEvent.value().toString())
+            hoverHtml.appendComponent(HookManager.render(hoverEvent.value() as Component))
+            addData(DATA_HOVER_EVENT_SHOW_TEXT, hoverHtml.toString())
         }
+        // unknown hover events are discarded FOR NOW
     }
 
     true


### PR DESCRIPTION
Working towards #22. I removed the style i had before because of license stuff but the rest of the code is there.

Not the best so i'm hoping for help with it, in particular the three event listeners look bad and ~~i'm not sure if there's a better way to not have things like `"show_text"` hard-coded~~

How it works is literally by showing the whole html of the hover into a data value thing and on mouseover just puts it into a high z-index absolute position div using `innerHTML`, which is then moved around

This PR intentionally skips show_entity and show_item hover events because hhhhhhhhhhhhh

[DEMO HOSTED HERE](https://webui.hydra.rymiel.space/?mode=chat_closed&input=%3Chover%3Ashow_text%3A%27hello%20%3Cred%3Eworld%3C%2Fred%3E%27%3Ehover%20me!%3C%2Fhover%3E)