### PR TITLE
Fix readme and centered motd

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ For more information, see [the wiki](https://github.com/KyoriPowered/adventure-w
 ### Deployment
 
 To run the server, type `./gradlew run -PisDevelopment`.
-This will create a server running at `https://localhost:8080`.
+This will create a server running at `http://localhost:8080`.
 
 For production usage, simply remove the development flag from the run task.
 Alternatively, the `distribution` tasks (for example, `distTar`) can be used to create or install archives that contain scripts to run the server.

--- a/src/commonMain/resources/web/css/style.css
+++ b/src/commonMain/resources/web/css/style.css
@@ -165,7 +165,6 @@
 #output-pre.mode-server-list {
     display: inline-flex;
     flex-direction: column;
-    align-items: center;
     line-height: 25px;
     background: none;
     padding-left: 10px;


### PR DESCRIPTION
This PR fixes #42 and replaces https with http in the deployment url in the readme, because the server doesn't seem to serve https requests. 