### PR TITLE
Dark mode

### DIFF
--- a/src/commonMain/resources/web/css/style.css
+++ b/src/commonMain/resources/web/css/style.css
@@ -191,9 +191,6 @@
 .gone {
     display: none;
 }
-body {
-    background-color: #E6E6E6;
-}
 html {
     overflow-y: hidden;
 }
@@ -210,4 +207,23 @@ html {
 }
 #server-list-image {
     width: 65px;
+}
+@media (prefers-color-scheme: light) {
+    body {
+        background-color: #E6E6E6;
+    }
+    .navbar {
+        background-color: #F5F5F5;
+    }
+}
+@media (prefers-color-scheme: dark) {
+    section.modal-card-body {
+        background-color: black;
+    }
+    div.modal-background {
+        background-color: rgba(10,10,10,.86);
+    }
+    table.table td, table.table th {
+        border-width: 0 0 1px;
+    }
 }

--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -15,6 +15,8 @@
     <!--suppress HtmlUnknownTarget --> <script src="js/main.js" defer></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css"
           integrity="sha256-UDtbUHqpVVfXmdJcQVU/bfDEr9xldf3Dbd0ShD0Uf/Y=" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-prefers-dark@0.1.0-beta.1/css/bulma-prefers-dark.css"
+          integrity="sha256-wQI3d0fArzMuGDTXVXZ+fCbB7NBZM+HRpD2My85B3PQ=" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/animate.css@4.1.1/animate.min.css"
           integrity="sha256-X7rrn44l1+AUO65h1LGALBbOc5C5bOstSYsNlv9MhT8=" crossorigin="anonymous">
     <link type="text/css" rel="stylesheet" href="css/style.css">
@@ -24,7 +26,7 @@
             integrity="sha256-S9DjwN1WDDoq2jChOYfPxbSYY4A30/U6oknr7khzsO0=" crossorigin="anonymous"></script>
   </head>
   <body>
-    <header class="navbar is-light is-clipped">
+    <header class="navbar is-clipped">
       <div class="navbar-brand">
         <a class="navbar-item" id="home-link">
           <h1 class="title mc-font">MiniMessage Viewer</h1>

--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -15,7 +15,7 @@
     <!--suppress HtmlUnknownTarget --> <script src="js/main.js" defer></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css"
           integrity="sha256-UDtbUHqpVVfXmdJcQVU/bfDEr9xldf3Dbd0ShD0Uf/Y=" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-prefers-dark@0.1.0-beta.1/css/bulma-prefers-dark.css"
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-prefers-dark@0.1.0-beta.1/css/bulma-prefers-dark.min.css"
           integrity="sha256-wQI3d0fArzMuGDTXVXZ+fCbB7NBZM+HRpD2My85B3PQ=" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/animate.css@4.1.1/animate.min.css"
           integrity="sha256-X7rrn44l1+AUO65h1LGALBbOc5C5bOstSYsNlv9MhT8=" crossorigin="anonymous">


### PR DESCRIPTION
Implements dark mode by just using [another dependency so we don't have to deal with the sass stuff](https://www.npmjs.com/package/bulma-prefers-dark), plus some extra style fixes because it's a little buggy.

There is no toggle, it is only enabled with the `prefers-color-scheme: dark` CSS `@media` selector, so it's up to the browser