### PR TITLE
Ask for confirmation when unloading

### DIFF
--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -23,6 +23,7 @@ import net.kyori.adventure.webui.websocket.Call
 import net.kyori.adventure.webui.websocket.Packet
 import net.kyori.adventure.webui.websocket.Placeholders
 import net.kyori.adventure.webui.websocket.Response
+import org.w3c.dom.BeforeUnloadEvent
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLAnchorElement
 import org.w3c.dom.HTMLDivElement
@@ -340,6 +341,18 @@ public fun main() {
             )
 
             installHoverManager()
+        }
+    )
+
+    window.addEventListener(
+        "beforeunload",
+        { event ->
+            val input = document.getElementById("input")!!.unsafeCast<HTMLTextAreaElement>()
+            if (input.value != "") {
+                val e = event as BeforeUnloadEvent
+                e.preventDefault()
+                e.returnValue = "" // Chrome
+            }
         }
     )
 }


### PR DESCRIPTION
As suggested by Glare [on Discord](https://canary.discord.com/channels/319355592605040642/420342659115122688/917981720714829864), it's a good idea to confirm whether a user really wants to leave the page if they have text entered, just to make sure they don't lose their progress.

Fixes #64.