### PR TITLE
Persistent settings storage

### DIFF
--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Background.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Background.kt
@@ -1,0 +1,33 @@
+package net.kyori.adventure.webui.js
+
+import kotlinx.browser.document
+import kotlinx.browser.window
+import org.w3c.dom.HTMLDivElement
+import org.w3c.dom.HTMLOptionElement
+import org.w3c.dom.HTMLSelectElement
+import org.w3c.dom.asList
+import org.w3c.dom.set
+
+private val outputPane: HTMLDivElement by lazy { document.getElementById("output-pane")!!.unsafeCast<HTMLDivElement>() }
+private val settingBackground: HTMLSelectElement by lazy { document.getElementById("setting-background")!!.unsafeCast<HTMLSelectElement>() }
+private val validBackgrounds: List<String> by lazy { settingBackground.options.asList().map { it.unsafeCast<HTMLOptionElement>().value } }
+public var currentBackground: String? = null
+    set(value) {
+        field = value
+        updateBackground()
+    }
+
+public fun updateBackground() {
+    val bg = currentBackground ?: return
+    if (!validBackgrounds.contains(currentBackground)) return
+    window.localStorage[PARAM_BACKGROUND] = bg
+    settingBackground.value = bg
+    if (currentMode == Mode.SERVER_LIST) {
+        // Remove the current background if we are switching to "server list"
+        // as it has a black background that is otherwise overridden
+        outputPane.style.removeProperty("background-image")
+    } else {
+        // Otherwise, try to put back the background from before
+        outputPane.style.backgroundImage = "url(\"img/$bg.jpg\")"
+    }
+}

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -53,15 +53,14 @@ private val urlParams: URLSearchParams by lazy { URLSearchParams(window.location
 
 private const val PARAM_INPUT: String = "input"
 private const val PARAM_MODE: String = "mode"
-private const val PARAM_BACKGROUND: String = "bg"
+public const val PARAM_BACKGROUND: String = "bg"
 private const val PARAM_STRING_PLACEHOLDERS: String = "st"
 private const val PARAM_COMPONENT_PLACEHOLDERS: String = "ct"
 
 private var isInEditorMode: Boolean = false
 private lateinit var editorInput: EditorInput
 
-private lateinit var currentMode: Mode
-private lateinit var currentBackground: String
+public lateinit var currentMode: Mode
 private lateinit var webSocket: WebSocket
 
 public fun main() {
@@ -197,26 +196,9 @@ public fun main() {
                 element.addEventListener("click", { UserPlaceholder.addToList() })
             }
 
-            // SETTINGS
-            val settingBackground = document.getElementById("setting-background")!!.unsafeCast<HTMLSelectElement>()
-            currentBackground = urlParams.getFromParamsOrLocalStorage(PARAM_BACKGROUND) ?: settingBackground.value
-            settingBackground.value = currentBackground // ???
-            outputPane.style.backgroundImage = "url(\"img/$currentBackground.jpg\")"
-            settingBackground.addEventListener(
-                "change",
-                {
-                    currentBackground = settingBackground.value
-                    window.localStorage[PARAM_BACKGROUND] = currentBackground
-                    outputPane.style.backgroundImage = "url(\"img/$currentBackground.jpg\")"
-                }
-            )
-
             // MODES
             val urlParams = URLSearchParams(window.location.search)
             currentMode = Mode.fromString(urlParams.getFromParamsOrLocalStorage(PARAM_MODE))
-            if (currentMode == Mode.SERVER_LIST) {
-                outputPane.style.removeProperty("background-image")
-            }
             outputPre.classList.add(currentMode.className)
             outputPane.classList.add(currentMode.className)
 
@@ -253,20 +235,23 @@ public fun main() {
                             }
                         }
 
-                        if (currentMode == Mode.SERVER_LIST) {
-                            // Remove the current background if we are switching to "server list"
-                            // as it has a black background that is otherwise overridden
-                            outputPane.style.removeProperty("background-image")
-                        } else {
-                            // Otherwise, try to put back the background from before
-                            outputPane.style.backgroundImage = "url(\"img/$currentBackground.jpg\")"
-                        }
+                        updateBackground()
 
                         // re-parse to remove the horrible server list header line hack
                         parse()
                     }
                 )
             }
+
+            // SETTINGS
+            val settingBackground = document.getElementById("setting-background")!!.unsafeCast<HTMLSelectElement>()
+            currentBackground = urlParams.getFromParamsOrLocalStorage(PARAM_BACKGROUND) ?: settingBackground.value
+            settingBackground.addEventListener(
+                "change",
+                {
+                    currentBackground = settingBackground.value
+                }
+            )
 
             // CLIPBOARD
             document.getElementById("link-share-button")!!.addEventListener(

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/PersistentStorage.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/PersistentStorage.kt
@@ -1,0 +1,21 @@
+package net.kyori.adventure.webui.js
+
+import kotlinx.browser.window
+import org.w3c.dom.get
+import org.w3c.dom.url.URLSearchParams
+
+/** Fetches an input passed from URL if there is one, otherwise tries to use local storage */
+public fun URLSearchParams.getFromParamsOrLocalStorage(key: String): String? {
+    val shared = this.get(key)
+    if (shared != null) {
+        val text = decodeURIComponent(shared)
+        println("SHARED $key: $text")
+        return text
+    } else {
+        window.localStorage[key]?.also { stored ->
+            println("STORED $key: $stored")
+            return stored
+        }
+    }
+    return null
+}


### PR DESCRIPTION
Resolves #37.

Unifies the logic of the URL parameters with localStorage. Changes are saved live to localStorage.
When opening a shared URL, the passed values from the parameters will be used, in other cases, localStorage is tried.
Also adds the background type into the shared URL (for example, [this link will always give you the "desert" background!](https://webui.hydra.rymiel.space/?mode=hologram&input=Hello%20desert!&bg=desert))