### PR TITLE
Begin updating for MM changes in adventure 4.10.0

### DIFF
--- a/gradle/libs.versions.conf
+++ b/gradle/libs.versions.conf
@@ -12,11 +12,12 @@ plugins = {
 
 versions = {
   ktor = "1.6.1"
+  adventure = "4.10.0-SNAPSHOT"
 }
 
 dependencies = {
-  adventure-minimessage = { group = "net.kyori", name = "adventure-text-minimessage", version = "4.2.0-SNAPSHOT" }
-  adventure-text-serializer-gson = { group = ${dependencies.adventure-minimessage.group}, name = "adventure-text-serializer-gson", version = "4.8.1" }
+  adventure-minimessage = { group = "net.kyori", name = "adventure-text-minimessage", version.ref = "adventure" }
+  adventure-text-serializer-gson = { group = ${dependencies.adventure-minimessage.group}, name = "adventure-text-serializer-gson", version.ref = "adventure" }
   cache4k = { group = "io.github.reactivecircus.cache4k", name = "cache4k", version = "0.3.0" }
   kotlinx-html = { group = "org.jetbrains.kotlinx", name = "kotlinx-html", version = "0.7.3" }
   kotlinx-serialization-json = { group = ${dependencies.kotlinx-html.group}, name = "kotlinx-serialization-json", version = "1.2.2" }

--- a/src/commonMain/kotlin/net/kyori/adventure/webui/websocket/Packet.kt
+++ b/src/commonMain/kotlin/net/kyori/adventure/webui/websocket/Packet.kt
@@ -15,8 +15,7 @@ public data class Call(public val miniMessage: String? = null) : Packet
 @SerialName("placeholders")
 public data class Placeholders(
     public val stringPlaceholders: Map<String, String>? = null,
-    public val componentPlaceholders: Map<String, JsonObject>? = null,
-    public val miniMessagePlaceholders: Map<String, String>? = null
+    public val componentPlaceholders: Map<String, JsonObject>? = null
 ) : Packet
 
 @Serializable

--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -206,7 +206,6 @@
             <table class="table is-striped is-hoverable is-fullwidth">
               <thead>
                 <tr>
-                  <th><abbr title="Tick to convert the replacement to a component using MiniMessage formatting">MM?</abbr></th>
                   <th>Key</th>
                   <th>Replacement</th>
                   <th></th>

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/UserPlaceholder.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/UserPlaceholder.kt
@@ -1,8 +1,6 @@
 package net.kyori.adventure.webui.js
 
 import kotlinx.browser.document
-import kotlinx.html.InputType
-import kotlinx.html.classes
 import kotlinx.html.dom.append
 import kotlinx.html.js.a
 import kotlinx.html.js.i
@@ -17,11 +15,9 @@ import org.w3c.dom.HTMLTableRowElement
 import org.w3c.dom.asList
 
 public class UserPlaceholder(
-    private val isMiniMessageCheckbox: HTMLInputElement,
     private val keyInput: HTMLInputElement,
     private val valueInput: HTMLInputElement
 ) {
-    public var isMiniMessage: Boolean by isMiniMessageCheckbox::checked
     public var key: String by keyInput::value
     public var value: String by valueInput::value
 
@@ -30,14 +26,10 @@ public class UserPlaceholder(
             val list = document.getElementById("placeholders-list")!!
             lateinit var key: HTMLInputElement
             lateinit var value: HTMLInputElement
-            lateinit var isMM: HTMLInputElement
             lateinit var row: HTMLTableRowElement
             lateinit var deleteButton: HTMLAnchorElement
             list.append {
                 row = tr {
-                    td(classes = "control is-vcentered has-text-centered") {
-                        isMM = input(type = InputType.checkBox, classes = "placeholder-component")
-                    }
                     td(classes = "control") { key = input(classes = "input placeholder-key") }
                     td(classes = "control") { value = input(classes = "input placeholder-value") }
                     td(classes = "control") {
@@ -52,15 +44,11 @@ public class UserPlaceholder(
                 }
             }
             deleteButton.addEventListener("click", { row.remove() })
-            return UserPlaceholder(isMM, key, value)
+            return UserPlaceholder(key, value)
         }
 
         public fun allInList(): List<UserPlaceholder> {
             val placeholdersBox = document.getElementById("placeholders-list")!!
-            val placeholderIsMM =
-                placeholdersBox.getElementsByClassName("placeholder-component").asList().map {
-                    it.unsafeCast<HTMLInputElement>()
-                }
             val placeholderKeys =
                 placeholdersBox.getElementsByClassName("placeholder-key").asList().map {
                     it.unsafeCast<HTMLInputElement>()
@@ -69,8 +57,8 @@ public class UserPlaceholder(
                 placeholdersBox.getElementsByClassName("placeholder-value").asList().map {
                     it.unsafeCast<HTMLInputElement>()
                 }
-            return placeholderIsMM.mapIndexed { i, _ ->
-                UserPlaceholder(placeholderIsMM[i], placeholderKeys[i], placeholderValues[i])
+            return placeholderKeys.mapIndexed { i, _ ->
+                UserPlaceholder(placeholderKeys[i], placeholderValues[i])
             }
         }
     }

--- a/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/MiniMessage.kt
+++ b/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/MiniMessage.kt
@@ -55,7 +55,7 @@ public val Placeholders?.placeholderResolver: PlaceholderResolver
     get() {
         if (this == null) return PlaceholderResolver.empty()
         val stringConverted =
-            this.stringPlaceholders?.map { Placeholder.miniMessage(it.key, it.value) } ?: listOf() // todo: is this correct? or do Component.text()
+            this.stringPlaceholders?.map { Placeholder.miniMessage(it.key, it.value) } ?: listOf()
         val componentConverted =
             this.componentPlaceholders?.map {
                 Placeholder.component(
@@ -63,14 +63,7 @@ public val Placeholders?.placeholderResolver: PlaceholderResolver
                 )
             }
                 ?: listOf()
-        val miniMessageConverted =
-            this.miniMessagePlaceholders?.map {
-                Placeholder.component(it.key, MiniMessage.miniMessage().deserialize(it.value))
-            }
-                ?: listOf()
-        return PlaceholderResolver.placeholders(
-            stringConverted + componentConverted + miniMessageConverted
-        )
+        return PlaceholderResolver.placeholders(stringConverted + componentConverted)
     }
 
 /** Entry-point for MiniMessage Viewer. */

--- a/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/MiniMessage.kt
+++ b/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/MiniMessage.kt
@@ -49,19 +49,18 @@ public val Placeholders?.tagResolver: TagResolver
     get() {
         if (this == null) return TagResolver.empty()
         val stringConverted =
-            this.stringPlaceholders?.map { Placeholder.parsed(it.key, it.value) } ?: listOf()
+            this.stringPlaceholders?.map { (key, value) ->
+                Placeholder.parsed(key, value)
+            } ?: listOf()
         val componentConverted =
-            this.componentPlaceholders?.map {
-                Placeholder.component(
-                    it.key, GsonComponentSerializer.gson().deserialize(it.value.toString())
-                )
-            }
-                ?: listOf()
+            this.componentPlaceholders?.map { (key, value) ->
+                Placeholder.component(key, GsonComponentSerializer.gson().deserialize(value.toString()))
+            } ?: listOf()
         return TagResolver.resolver(stringConverted + componentConverted)
     }
 
 /** Entry-point for MiniMessage Viewer. */
-public fun Application.minimessage() {
+public fun Application.miniMessage() {
     // add standard renderers
     HookManager.apply {
         component(HOVER_EVENT_RENDER_HOOK)

--- a/src/jvmMain/resources/application.conf
+++ b/src/jvmMain/resources/application.conf
@@ -1,16 +1,16 @@
 ktor {
-    deployment {
-        port = 8080
-    }
+  deployment {
+    port = 8080
+  }
 
-    application {
-        modules = [
-            net.kyori.adventure.webui.jvm.ApplicationKt.main,
-            net.kyori.adventure.webui.jvm.minimessage.MiniMessageKt.minimessage
-        ]
-    }
+  application {
+    modules = [
+      net.kyori.adventure.webui.jvm.ApplicationKt.main,
+      net.kyori.adventure.webui.jvm.minimessage.MiniMessageKt.miniMessage
+    ]
+  }
 
-    config {
-        jsScriptFile = "$jsScriptFile"
-    }
+  config {
+    jsScriptFile = "$jsScriptFile"
+  }
 }


### PR DESCRIPTION
Currently the webui interacts with things I'd consider to be implementation details within MM itself in order to get the tree, and so has not been modified for the removal of `Context.of`.

I believe MiniMessage will need to have some view of the parse tree exposed in order to fully update the webui for new changes.