### PR TITLE
Revamp server list to include header in HTML, not when parsing

### DIFF
--- a/src/commonMain/resources/web/css/style.css
+++ b/src/commonMain/resources/web/css/style.css
@@ -41,17 +41,21 @@
     background-image: url("../img/grass.jpg");
     background-size: cover;
 }
-#output-pane #server-list-icon {
+#output-pane #server-list-icon,
+#output-pane #server-list-header {
     display: none;
 }
-#output-pane.mode-chat-open, #output-pane.mode-chat-closed {
+#output-pane.mode-chat-open > #output-lines,
+#output-pane.mode-chat-closed > #output-lines {
     background-position: bottom left;
     display: flex;
     align-items: flex-end;
 }
-#output-pane.mode-chat-open {
+#output-pane.mode-chat-open,
+#output-pane.mode-chat-open > #output-lines {
     flex-direction: column-reverse;
     align-items: flex-start;
+    width: 100%;
 }
 #output-pane:not(.mode-chat-open) > #chat-entry-box {
     display: none;
@@ -66,14 +70,14 @@
     font-size: 32px;
     padding-left: 5px;
 }
-#output-pane.mode-hologram {
+#output-pane.mode-hologram > #output-lines {
     background-position: center center;
     align-items: center;
     display: flex;
     justify-content: center;
     align-content: center;
 }
-#output-pane.mode-lore {
+#output-pane.mode-lore > #output-lines {
     background-position: center center;
     align-items: center;
     display: flex;
@@ -84,12 +88,23 @@
     background-image: url("../img/server_list_background.jpg");
     background-size: auto;
     align-items: center;
-    display: flex;
     align-content: center;
     justify-content: center;
 }
+#output-pane.mode-server-list > #output-lines {
+    align-items: flex-start;
+    flex-direction: column;
+    display: inline-flex;
+    line-height: 25px;
+    padding-left: 10px;
+    max-width: 546px;
+}
 #output-pane.mode-server-list #server-list-icon {
     display: block;
+}
+#output-pane.mode-server-list #server-list-header {
+    display: flex;
+    width: 100%;
 }
 /* output pre */
 #output-pre:empty {
@@ -167,15 +182,17 @@
 #output-pre.mode-server-list {
     display: inline-flex;
     flex-direction: column;
-    line-height: 25px;
     background: none;
-    padding-left: 10px;
+    padding: 0;
+    margin-bottom: 0;
+    max-width: 100%;
+    overflow: hidden;
     color: #555555;
-    text-shadow: none !important;
 }
 #output-pre.mode-server-list span {
     font-size: 20px;
     line-height: 20px;
+    text-shadow: none !important;
 }
 #hover-tooltip {
     position: fixed;

--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -182,12 +182,20 @@
           <div hidden id="hover-tooltip" class="mc-font"></div>
           <div class="column is-full is-flex is-flex-direction-column">
             <label for="output-pane">Output: </label>
-            <div id="output-pane" class="is-flex-grow-1 is-flex-shrink-0">
+            <div id="output-pane" class="is-flex is-flex-grow-1 is-flex-shrink-0">
               <div id="chat-entry-box">_</div>
               <div id="server-list-icon">
                 <img id="server-list-image" src="img/kyori.png" alt="Example server icon">
               </div>
-              <pre id="output-pre" class="mc-font"></pre>
+              <div id="output-lines" class="is-flex-grow-1 is-flex-shrink-0">
+                <div id="server-list-header" class="mc-font">
+                  <span style="color: white;">KyoriCraft</span>
+                  <span style="color: #aaaaaa;margin-left: auto;">
+                    0<span style="color: #555555;">/</span>20
+                  </span>
+                </div>
+                <pre id="output-pre" class="mc-font"></pre>
+              </div>
             </div>
           </div>
         </div>

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -229,9 +229,6 @@ public fun main() {
                         }
 
                         updateBackground()
-
-                        // re-parse to remove the horrible server list header line hack
-                        parse()
                     }
                 )
             }
@@ -510,10 +507,7 @@ private fun parse() {
                     when (currentMode) {
                         Mode.CHAT_CLOSED -> list.safeSubList(0, 10)
                         Mode.SERVER_LIST ->
-                            buildList(3) {
-                                add(
-                                    "KyoriCraft                                                 <gray>0<dark_gray>/</dark_gray>20"
-                                )
+                            buildList(2) {
                                 add(list.getOrNull(0) ?: "\u200B")
                                 add(list.getOrNull(1) ?: "\u200B")
                             }


### PR DESCRIPTION
Creates an extra layer around the output `pre` tag, which causes some jank CSS as most, but not all styles that were previously on `output-pane` now go on this layer instead. I could not find a better way to organize these while also keeping the icon where it should be. (at least it fixes a different jank)
Also makes the server list name white, as it is in-game. Also fixes server list's no text shadow not applying always.

Note: The width value of 546px is completely arbitrary and chosen only by how large the box was previously, there's probably a better or more accurate value that goes here