### PR TITLE
Only handle newlines as separate parses when in lore mode

### DIFF
--- a/src/commonMain/kotlin/net/kyori/adventure/webui/websocket/Packet.kt
+++ b/src/commonMain/kotlin/net/kyori/adventure/webui/websocket/Packet.kt
@@ -9,7 +9,10 @@ public sealed interface Packet
 
 @Serializable
 @SerialName("call")
-public data class Call(public val miniMessage: String? = null) : Packet
+public data class Call(
+    public val miniMessage: String? = null,
+    public val isolateNewlines: Boolean = false
+) : Packet
 
 @Serializable
 @SerialName("placeholders")

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -399,13 +399,9 @@ private fun onWebsocketReady() {
                     if (result.success && result.dom != null) {
                         output.textContent = ""
 
-                        result.dom.split("\n").forEach { line ->
-                            if (line.isNotEmpty()) {
-                                document.createElement("div").also { div ->
-                                    div.innerHTML = line
-                                    output.append(div)
-                                }
-                            }
+                        document.createElement("div").also { div ->
+                            div.innerHTML = result.dom.replace("\n", "<br>")
+                            output.append(div)
                         }
 
                         // reset scroll to bottom (like how chat works)
@@ -521,7 +517,7 @@ private fun parse() {
                     if (line == "") "\u200B" else line
                 }
 
-            webSocket.send(Call(combinedLines))
+            webSocket.send(Call(combinedLines, isolateNewlines = currentMode == Mode.LORE))
         }
     }
 }
@@ -533,7 +529,7 @@ private fun WebSocket.send(packet: Packet) {
     this.send(Serializers.json.encodeToString(packet))
 }
 
-private inline fun <reified T : Packet> Window.postPacket(url: String, packet: T): Promise<org.w3c.fetch.Response> {
+private inline fun <reified T> Window.postPacket(url: String, packet: T): Promise<org.w3c.fetch.Response> {
     return this.fetch(
         url,
         RequestInit(


### PR DESCRIPTION
Currently, the backend splits all newlines and parses the split-up
messages with completely separate MiniMessage instances so they have
separate parents. With this change, this will be only done when in lore
mode, and newlines will simply remain in the message regularly in all
other modes.

The justification for this is the fact that newlines can't appear in
lores at all, as the client will render them in a tofubox. Therefore
having newlines in the lore mode in the webui implies the fact that
these are in fact separate lines with separate tree roots.

This isn't explained on the site though, maybe it should be...

Part one of making webui less horrible with newlines