### PR TITLE
fix: re-parse when switching modes

### DIFF
--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -230,6 +230,7 @@ public fun main() {
                         }
 
                         updateBackground()
+                        parse()
                     }
                 )
             }


### PR DESCRIPTION
As part of #79 I ripped out a hack which reparsed the message when switching modes, however, without this, after #81 switching between lore and non-lore mode wouldn't update the newline processing mode, leading to sudden changes when modifying the input.

This alleged "hack" of a reparse isn't that bad IMO, not really an overhead or anything considering a reparse is done anyway for every single input change