### PR TITLE
fix: Try-catch around constructing placeholders

### DIFF
--- a/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/MiniMessage.kt
+++ b/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/MiniMessage.kt
@@ -50,13 +50,21 @@ public val Placeholders?.tagResolver: TagResolver
         if (this == null) return TagResolver.empty()
         val stringConverted =
             this.stringPlaceholders?.map { (key, value) ->
-                Placeholder.parsed(key, value)
+                try {
+                    Placeholder.parsed(key, value)
+                } catch (_: java.lang.IllegalArgumentException) {
+                    null
+                }
             } ?: listOf()
         val componentConverted =
             this.componentPlaceholders?.map { (key, value) ->
-                Placeholder.component(key, GsonComponentSerializer.gson().deserialize(value.toString()))
+                try {
+                    Placeholder.component(key, GsonComponentSerializer.gson().deserialize(value.toString()))
+                } catch (_: java.lang.IllegalArgumentException) {
+                    null
+                }
             } ?: listOf()
-        return TagResolver.resolver(stringConverted + componentConverted)
+        return TagResolver.resolver((stringConverted + componentConverted).filterNotNull())
     }
 
 /** Entry-point for MiniMessage Viewer. */

--- a/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/editor/EditorRoute.kt
+++ b/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/editor/EditorRoute.kt
@@ -18,12 +18,12 @@ import net.kyori.adventure.webui.URL_EDITOR_OUTPUT
 import net.kyori.adventure.webui.editor.EditorInput
 import net.kyori.adventure.webui.tryDecodeFromString
 import java.util.UUID
-import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 private val inputSessions: Cache<String, EditorInput> =
-    Cache.Builder().expireAfterWrite(Duration.minutes(5)).build()
+    Cache.Builder().expireAfterWrite(5.minutes).build()
 private val outputSessions: Cache<String, String> =
-    Cache.Builder().expireAfterWrite(Duration.minutes(5)).build()
+    Cache.Builder().expireAfterWrite(5.minutes).build()
 
 /** Installs routes for the editor system */
 public fun Route.installEditor() {


### PR DESCRIPTION
Fixes #87

Ugly code but this at least preserves all other placeholders while filtering out the invalid ones

Also replaces kotlin deprecated `minutes(Int): Duration` with `Int.minutes extension property from Duration.Companion`