### PR TITLE
feat: Short links!

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,7 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation(libs.bundles.ktor.server)
+                implementation(libs.bundles.ktor.client)
 
                 implementation(libs.adventure.minimessage)
                 implementation(libs.adventure.text.serializer.gson)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,8 +17,11 @@ kotlinx-html = { group = "org.jetbrains.kotlinx", name = "kotlinx-html", version
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.3.2" }
 ktor-server-core = { group = "io.ktor", name = "ktor-server-core", version.ref = "ktor" }
 ktor-server-netty = { group = "io.ktor", name = "ktor-server-netty", version.ref = "ktor" }
+ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
 ktor-websockets = { group = "io.ktor", name = "ktor-websockets", version.ref = "ktor" }
 logback-classic = { group = "ch.qos.logback", name = "logback-classic", version = "1.2.11" }
 
 [bundles]
 ktor-server = [ "ktor-server-core", "ktor-server-netty", "ktor-websockets" ]
+ktor-client = [ "ktor-client-core", "ktor-client-okhttp" ]

--- a/src/commonMain/kotlin/net/kyori/adventure/webui/Constants.kt
+++ b/src/commonMain/kotlin/net/kyori/adventure/webui/Constants.kt
@@ -38,3 +38,6 @@ public const val URL_EDITOR_OUTPUT: String = "/output"
 
 /** Parameter for obtaining editor data. */
 public const val PARAM_EDITOR_TOKEN: String = "token"
+
+/** Path for getting a short link for a MiniMessage input. */
+public const val URL_MINI_SHORTEN: String = "/mini-shorten"

--- a/src/commonMain/kotlin/net/kyori/adventure/webui/websocket/Packet.kt
+++ b/src/commonMain/kotlin/net/kyori/adventure/webui/websocket/Packet.kt
@@ -24,5 +24,7 @@ public data class Placeholders(
 @Serializable
 public data class Combined(
     public val miniMessage: String? = null,
-    public val placeholders: Placeholders? = null
+    public val placeholders: Placeholders? = null,
+    public val background: String? = null,
+    public val mode: String? = null
 )

--- a/src/commonMain/resources/web/css/style.css
+++ b/src/commonMain/resources/web/css/style.css
@@ -218,6 +218,9 @@ html {
 .hero {
     padding-bottom: 15px;
 }
+.share-dropdown {
+    margin-right: .5rem;
+}
 .notification {
     display: flex;
     align-items: center;

--- a/src/commonMain/resources/web/css/style.css
+++ b/src/commonMain/resources/web/css/style.css
@@ -221,7 +221,8 @@ html {
 .share-dropdown {
     margin-right: .5rem;
 }
-.notification {
+.notification,
+.notification > div {
     display: flex;
     align-items: center;
     flex-direction: column;

--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -167,6 +167,7 @@
                   </button>
                 </div>
               </div>
+              <!-- TODO(rymiel): These decorations which don't work in non-chat contexts should probably be hidden when in that mode -->
               <div class="is-flex ml-1">
                 <div class="buttons has-addons is-right">
                   <button class="button" id="editor-open-url-button" aria-label="Open URL" title="Add clickable URL">

--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -124,7 +124,7 @@
               <label for="input">Input: </label>
               <div class="is-flex ml-auto">
                 <div class="dropdown">
-                  <div class="dropdown-trigger">
+                  <div class="dropdown-trigger swatch-trigger">
                     <button class="button" aria-haspopup="true" aria-controls="palette-dropdown-menu">
                       <span class="icon is-small">
                         <i class="fas fa-palette" aria-hidden="true"></i>

--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -64,6 +64,9 @@
               <button class="button" id="link-share-button" aria-label="Share" title="Share">
                 <span class="icon is-small"><i class="fas fa-share-alt"></i></span>
               </button>
+              <button class="button is-danger" id="temporary-short-link-share-button" aria-label="Share" title="Share">
+                <span class="icon is-small"><i class="fas fa-share-alt"></i></span>
+              </button>
               <button class="button" id="export-to-json-button" aria-label="Export to JSON" title="Export to JSON">
                 <span class="icon is-small"><i class="fas fa-file-export"></i></span>
               </button>

--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -229,6 +229,7 @@
       </div>
     </section>
 
+    <!-- MODALS -->
     <div id="placeholders-box" class="modal">
       <div class="modal-background placeholders-button"></div>
       <div class="modal-card">
@@ -257,6 +258,24 @@
         <footer class="modal-card-foot">
           <a class="button add-placeholder-button" aria-label="Add placeholder" title="Add placeholder">
             <span class="icon is-small"><i class="fas fa-plus"></i></span><span> Add placeholder</span>
+          </a>
+        </footer>
+      </div>
+    </div>
+
+    <div id="copy-modal" class="modal">
+      <div class="modal-background close-copy-modal"></div>
+      <div class="modal-card">
+        <header class="modal-card-head">
+          <p id="copy-modal-title" class="modal-card-title"></p>
+          <button class="delete close-copy-modal"></button>
+        </header>
+        <section class="modal-card-body">
+          <pre id="copy-modal-body"></pre>
+        </section>
+        <footer class="modal-card-foot">
+          <a id="copy-modal-button" class="button close-copy-modal" aria-label="Click to copy" title="Click to copy">
+            <span class="icon is-small"><i class="fas fa-copy"></i></span><span> Click to copy</span>
           </a>
         </footer>
       </div>

--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -75,8 +75,7 @@
                 <div class="dropdown-menu" id="share-dropdown-menu" role="menu">
                   <div class="dropdown-content">
                     <div class="dropdown-item">
-                      <!-- TODO(rymiel): maybe should be more specific? -->
-                      <p>Short links may expire!</p>
+                      <p>Short links expire after 6 months!</p>
                     </div>
                     <div class="dropdown-item">
                       <button class="button is-info share-button" id="short-link-share-button" aria-label="Share short link" title="Share short link">

--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -28,7 +28,7 @@
             integrity="sha256-XQju26ya9yEvX99+M2rrLah6xHsjZIGK1LvX/L3RjQ0=" crossorigin="anonymous"></script>
   </head>
   <body>
-    <header class="navbar is-clipped">
+    <header class="navbar">
       <div class="navbar-brand">
         <a class="navbar-item" id="home-link">
           <h1 class="title mc-font">MiniMessage Viewer</h1>
@@ -61,12 +61,34 @@
               <button class="button" id="copy-button" aria-label="Copy input" title="Copy input">
                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
               </button>
-              <button class="button" id="link-share-button" aria-label="Share" title="Share">
-                <span class="icon is-small"><i class="fas fa-share-alt"></i></span>
-              </button>
-              <button class="button is-danger" id="temporary-short-link-share-button" aria-label="Share" title="Share">
-                <span class="icon is-small"><i class="fas fa-share-alt"></i></span>
-              </button>
+              <div class="dropdown share-dropdown">
+                <div class="dropdown-trigger">
+                  <button class="button" aria-haspopup="true" aria-controls="share-dropdown-menu">
+                    <span class="icon is-small">
+                      <i class="fas fa-share-alt"></i>
+                    </span>
+                    <span class="icon is-small">
+                      <i class="fas fa-angle-down" aria-hidden="true"></i>
+                    </span>
+                  </button>
+                </div>
+                <div class="dropdown-menu" id="share-dropdown-menu" role="menu">
+                  <div class="dropdown-content">
+                    <div class="dropdown-item">
+                      <!-- TODO(rymiel): maybe should be more specific? -->
+                      <p>Short links may expire!</p>
+                    </div>
+                    <div class="dropdown-item">
+                      <button class="button is-info share-button" id="short-link-share-button" aria-label="Share short link" title="Share short link">
+                        Share short link
+                      </button>
+                      <button class="button is-info share-button" id="full-link-share-button" aria-label="Share full link" title="Share full link">
+                        Share full link
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
               <button class="button" id="export-to-json-button" aria-label="Export to JSON" title="Export to JSON">
                 <span class="icon is-small"><i class="fas fa-file-export"></i></span>
               </button>
@@ -103,13 +125,13 @@
               <div class="is-flex ml-auto">
                 <div class="dropdown">
                   <div class="dropdown-trigger">
-                    <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
+                    <button class="button" aria-haspopup="true" aria-controls="palette-dropdown-menu">
                       <span class="icon is-small">
                         <i class="fas fa-palette" aria-hidden="true"></i>
                       </span>
                     </button>
                   </div>
-                  <div class="dropdown-menu" id="dropdown-menu" role="menu">
+                  <div class="dropdown-menu" id="palette-dropdown-menu" role="menu">
                     <div class="dropdown-content">
                       <div class="dropdown-item">
                         <div id="picker"></div>

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/BytebinStorage.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/BytebinStorage.kt
@@ -8,7 +8,6 @@ import net.kyori.adventure.webui.websocket.Combined
 import net.kyori.adventure.webui.websocket.Placeholders
 import org.w3c.dom.HTMLTextAreaElement
 import org.w3c.dom.WebSocket
-import org.w3c.dom.url.URLSearchParams
 import org.w3c.fetch.Headers
 import org.w3c.fetch.RequestInit
 import kotlin.js.Json
@@ -52,13 +51,19 @@ public fun restoreFromShortLink(shortCode: String, inputBox: HTMLTextAreaElement
         val stringPlaceholders = structure.getFromCombinedOrLocalStorage(
             PARAM_STRING_PLACEHOLDERS,
             { c -> c.placeholders?.stringPlaceholders },
-            { inputString -> Serializers.json.tryDecodeFromString(inputString) } // WTF
+            { str -> Serializers.json.tryDecodeFromString(str) } // WTF
         )
         stringPlaceholders?.forEach { (k, v) ->
             UserPlaceholder.addToList().apply {
                 key = k
                 value = v
             }
+        }
+        structure.getFromCombinedOrLocalStorage(PARAM_BACKGROUND, Combined::background)?.also { background ->
+            currentBackground = background
+        }
+        structure.getFromCombinedOrLocalStorage(PARAM_MODE, Combined::mode)?.also { mode ->
+            setMode(Mode.fromString(mode))
         }
         webSocket.send(
             Placeholders(stringPlaceholders = stringPlaceholders)

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/BytebinStorage.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/BytebinStorage.kt
@@ -13,6 +13,7 @@ import org.w3c.dom.WebSocket
 import org.w3c.dom.url.URLSearchParams
 import org.w3c.fetch.Headers
 import org.w3c.fetch.RequestInit
+import kotlin.js.Json
 import kotlin.js.Promise
 import kotlin.js.json
 
@@ -34,7 +35,9 @@ public fun bytebinStore(payload: Combined): Promise<String?> {
                 headers = Headers(json("Content-Type" to "application/json; charset=UTF-8")),
                 body = Serializers.json.encodeToString(payload)
             )
-        ).then { response -> response.headers.get("Location") }
+        )
+            .then { response -> response.json() }
+            .then { json -> json.unsafeCast<Json>()["key"].unsafeCast<String>() } // :I
     } else {
         window.postPacket("$URL_API$URL_MINI_SHORTEN", payload)
             .then { response -> response.text() }

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/BytebinStorage.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/BytebinStorage.kt
@@ -3,8 +3,6 @@ package net.kyori.adventure.webui.js
 import kotlinx.browser.window
 import kotlinx.serialization.encodeToString
 import net.kyori.adventure.webui.Serializers
-import net.kyori.adventure.webui.URL_API
-import net.kyori.adventure.webui.URL_MINI_SHORTEN
 import net.kyori.adventure.webui.tryDecodeFromString
 import net.kyori.adventure.webui.websocket.Combined
 import net.kyori.adventure.webui.websocket.Placeholders
@@ -19,49 +17,25 @@ import kotlin.js.json
 
 private const val BYTEBIN_INSTANCE: String = "https://bytebin.lucko.me"
 
-/** Since it's sorta undecided whether to use client- or server-sided bytebin integration, here's just a toggle
- * for it. When using server-side integration, the server essentially just acts pretty much like a direct proxy
- * to bytebin, as there is no additional logic needed. The client could also do all of it on its own much more directly,
- * however there are also some downsides to that...
- */
-private const val CLIENTSIDE_BYTEBIN: Boolean = true
-
 public fun bytebinStore(payload: Combined): Promise<String?> {
-    val request = if (CLIENTSIDE_BYTEBIN) {
-        window.fetch(
-            "$BYTEBIN_INSTANCE/post",
-            RequestInit(
-                method = "POST",
-                headers = Headers(json("Content-Type" to "application/json; charset=UTF-8")),
-                body = Serializers.json.encodeToString(payload)
-            )
+    return window.fetch(
+        "$BYTEBIN_INSTANCE/post",
+        RequestInit(
+            method = "POST",
+            headers = Headers(json("Content-Type" to "application/json; charset=UTF-8")),
+            body = Serializers.json.encodeToString(payload)
         )
-            .then { response -> response.json() }
-            .then { json -> json.unsafeCast<Json>()["key"].unsafeCast<String>() } // :I
-    } else {
-        window.postPacket("$URL_API$URL_MINI_SHORTEN", payload)
-            .then { response -> response.text() }
-            .then { i -> i } // :I
-    }
-
-    return request
+    )
+        .then { response -> response.json() }
+        .then { json -> json.unsafeCast<Json>()["key"].unsafeCast<String>() } // :I
 }
 
 private fun bytebinLoad(code: String): Promise<Combined?> {
     // TODO(rymiel): handle the 404 case
-    val request = if (CLIENTSIDE_BYTEBIN) {
-        window.fetch(
-            "$BYTEBIN_INSTANCE/$code",
-            RequestInit(method = "GET")
-        )
-    } else {
-        window.fetch(
-            "$URL_API$URL_MINI_SHORTEN?code=$code",
-            RequestInit(method = "GET")
-        )
-    }
-
-    return request
+    return window.fetch(
+        "$BYTEBIN_INSTANCE/$code",
+        RequestInit(method = "GET")
+    )
         .then { response -> response.text() }
         .then { text -> Serializers.json.tryDecodeFromString(text) }
 }

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/BytebinStorage.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/BytebinStorage.kt
@@ -43,8 +43,8 @@ private fun bytebinLoad(code: String): Promise<Combined?> {
 // TODO(rymiel): This probably shouldn't return a promise...?
 // The fact that this makes an additional web request probably causes weird delayed jumps in the output once it loads?
 // TODO(rymiel): Perhaps it could show some loading thing while it fetches the data for a short code
-public fun restoreFromShortLink(urlParams: URLSearchParams, inputBox: HTMLTextAreaElement, webSocket: WebSocket): Promise<Unit> {
-    return bytebinLoad(urlParams.get(PARAM_SHORT_LINK)!!).then { structure ->
+public fun restoreFromShortLink(shortCode: String, inputBox: HTMLTextAreaElement, webSocket: WebSocket): Promise<Unit> {
+    return bytebinLoad(shortCode).then { structure ->
         // This is rather duplicated from Main.kt :(
         structure.getFromCombinedOrLocalStorage(PARAM_INPUT, Combined::miniMessage)?.also { inputString ->
             inputBox.value = inputString

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/BytebinStorage.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/BytebinStorage.kt
@@ -1,0 +1,64 @@
+package net.kyori.adventure.webui.js
+
+import kotlinx.browser.window
+import kotlinx.serialization.encodeToString
+import net.kyori.adventure.webui.Serializers
+import net.kyori.adventure.webui.URL_API
+import net.kyori.adventure.webui.URL_MINI_SHORTEN
+import net.kyori.adventure.webui.tryDecodeFromString
+import net.kyori.adventure.webui.websocket.Combined
+import net.kyori.adventure.webui.websocket.Placeholders
+import org.w3c.dom.HTMLTextAreaElement
+import org.w3c.dom.WebSocket
+import org.w3c.dom.url.URLSearchParams
+import org.w3c.fetch.Headers
+import org.w3c.fetch.RequestInit
+import kotlin.js.Promise
+import kotlin.js.json
+
+private const val BYTEBIN_INSTANCE: String = "https://bytebin.lucko.me"
+
+/** Since it's sorta undecided whether to use client- or server-sided bytebin integration, here's just a toggle
+ * for it. When using server-side integration, the server essentially just acts pretty much like a direct proxy
+ * to bytebin, as there is no additional logic needed. The client could also do all of it on its own much more directly,
+ * however there are also some downsides to that...
+ */
+private const val CLIENTSIDE_BYTEBIN: Boolean = true
+
+public fun bytebinStore(payload: Combined): Promise<String?> {
+    val request = if (CLIENTSIDE_BYTEBIN) {
+        window.fetch(
+            "$BYTEBIN_INSTANCE/post",
+            RequestInit(
+                method = "POST",
+                headers = Headers(json("Content-Type" to "application/json; charset=UTF-8")),
+                body = Serializers.json.encodeToString(payload)
+            )
+        ).then { response -> response.headers.get("Location") }
+    } else {
+        window.postPacket("$URL_API$URL_MINI_SHORTEN", payload)
+            .then { response -> response.text() }
+            .then { i -> i } // :I
+    }
+
+    return request
+}
+
+private fun bytebinLoad(code: String): Promise<Combined?> {
+    // TODO(rymiel): handle the 404 case
+    val request = if (CLIENTSIDE_BYTEBIN) {
+        window.fetch(
+            "$BYTEBIN_INSTANCE/$code",
+            RequestInit(method = "GET")
+        )
+    } else {
+        window.fetch(
+            "$URL_API$URL_MINI_SHORTEN?code=$code",
+            RequestInit(method = "GET")
+        )
+    }
+
+    return request
+        .then { response -> response.text() }
+        .then { text -> Serializers.json.tryDecodeFromString(text) }
+}

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/BytebinStorage.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/BytebinStorage.kt
@@ -41,10 +41,14 @@ private fun bytebinLoad(code: String): Promise<Combined?> {
 
 // TODO(rymiel): This probably shouldn't return a promise...?
 // The fact that this makes an additional web request probably causes weird delayed jumps in the output once it loads?
-// TODO(rymiel): Perhaps it could show some loading thing while it fetches the data for a short code
+// TODO(rymiel): Perhaps it could show some loading thing while it fetches the data for a short code. This could apply to the site loading as a whole, it's not exactly blazing fast
 public fun restoreFromShortLink(shortCode: String, inputBox: HTMLTextAreaElement, webSocket: WebSocket): Promise<Unit> {
     return bytebinLoad(shortCode).then { structure ->
         // This is rather duplicated from Main.kt :(
+        /*
+        TODO(rymiel): since the `Combined` class is really being abused here, since that was made for websocket communication, this should be separated out to its own data class,
+          which could then implement a common interface or something with what's being done in Main.kt
+         */
         structure.getFromCombinedOrLocalStorage(PARAM_INPUT, Combined::miniMessage)?.also { inputString ->
             inputBox.value = inputString
         }

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/CopyModal.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/CopyModal.kt
@@ -1,0 +1,47 @@
+package net.kyori.adventure.webui.js
+
+import kotlinx.browser.document
+import kotlinx.browser.window
+import org.w3c.dom.Element
+import org.w3c.dom.HTMLAnchorElement
+import org.w3c.dom.HTMLDivElement
+import org.w3c.dom.HTMLParagraphElement
+import org.w3c.dom.HTMLPreElement
+import org.w3c.dom.asList
+
+private val modal: HTMLDivElement by lazy { document.getElementById("copy-modal")!!.unsafeCast<HTMLDivElement>() }
+private val modalTitle: HTMLParagraphElement by lazy { document.getElementById("copy-modal-title")!!.unsafeCast<HTMLParagraphElement>() }
+private val modalBody: HTMLPreElement by lazy { document.getElementById("copy-modal-body")!!.unsafeCast<HTMLPreElement>() }
+private val modalButton: HTMLAnchorElement by lazy { document.getElementById("copy-modal-button")!!.unsafeCast<HTMLAnchorElement>() }
+private val modalClose: List<Element> by lazy { document.getElementsByClassName("close-copy-modal").asList() }
+private var eventListenerSet = false
+
+// TODO(rymiel): Use this in more places where copying doesn't work i.e. the editor API safe button
+public fun createCopyModal(title: String, body: String) {
+    modal.classList.add("is-active")
+    modalTitle.innerText = title
+    modalBody.innerText = body
+
+    if (!eventListenerSet) {
+        eventListenerSet = true
+
+        modalButton.addEventListener(
+            "click",
+            {
+                val text = modalBody.innerText
+                window.navigator.clipboard.writeText(text).catch { error ->
+                    console.log(error) // Give up on trying to copy the thing
+                }
+            }
+        )
+
+        modalClose.forEach { element ->
+            element.addEventListener(
+                "click",
+                {
+                    modal.classList.remove("is-active")
+                }
+            )
+        }
+    }
+}

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/ExternalFunctions.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/ExternalFunctions.kt
@@ -3,6 +3,7 @@
 
 package net.kyori.adventure.webui.js
 
+import org.w3c.dom.HTMLElement
 import kotlin.js.Json
 import kotlin.js.json
 
@@ -20,5 +21,8 @@ public external class bulmaToast {
 }
 
 public fun bulmaToast.Companion.toast(message: String, type: String = "is-success") {
+    this.toast(json("message" to message, "type" to type))
+}
+public fun bulmaToast.Companion.toast(message: HTMLElement, type: String = "is-success") {
     this.toast(json("message" to message, "type" to type))
 }

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/ExternalFunctions.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/ExternalFunctions.kt
@@ -3,7 +3,10 @@
 
 package net.kyori.adventure.webui.js
 
-import org.w3c.dom.HTMLElement
+import kotlinx.browser.document
+import kotlinx.html.DIV
+import kotlinx.html.div
+import kotlinx.html.dom.create
 import kotlin.js.Json
 import kotlin.js.json
 
@@ -23,7 +26,8 @@ public external class bulmaToast {
 public fun bulmaToast.Companion.toast(message: String, type: String = "is-success") {
     this.toast(json("message" to message, "type" to type))
 }
-// TODO: this could instead yield a DIV allowing it to be used like `toast { ... }`
-public fun bulmaToast.Companion.toast(message: HTMLElement, type: String = "is-success") {
-    this.toast(json("message" to message, "type" to type))
+
+public inline fun bulmaToast.Companion.toast(type: String = "is-success", crossinline block: DIV.() -> Unit) {
+    val element = document.create.div(block = block)
+    this.toast(json("message" to element, "type" to type))
 }

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/ExternalFunctions.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/ExternalFunctions.kt
@@ -23,6 +23,7 @@ public external class bulmaToast {
 public fun bulmaToast.Companion.toast(message: String, type: String = "is-success") {
     this.toast(json("message" to message, "type" to type))
 }
+// TODO: this could instead yield a DIV allowing it to be used like `toast { ... }`
 public fun bulmaToast.Companion.toast(message: HTMLElement, type: String = "is-success") {
     this.toast(json("message" to message, "type" to type))
 }

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -11,7 +11,6 @@ import kotlinx.html.i
 import kotlinx.html.js.onClickFunction
 import kotlinx.html.p
 import kotlinx.html.span
-import kotlinx.html.stream.appendHTML
 import kotlinx.serialization.encodeToString
 import net.kyori.adventure.webui.COMPONENT_CLASS
 import net.kyori.adventure.webui.DATA_CLICK_EVENT_ACTION
@@ -496,15 +495,15 @@ private fun checkClickEvents(target: EventTarget?, typesToCheck: Collection<Even
                 val content = target.dataset[DATA_CLICK_EVENT_VALUE.camel] ?: ""
                 val actionName = clickAction.replace('_', ' ').replaceFirstChar(Char::uppercase)
                 bulmaToast.toast(
-                    buildString {
-                        appendHTML().p {
+                    document.create.div {
+                        p {
                             b { text("Click Event") }
                         }
-                        appendHTML().p {
+                        p {
                             text("Action: ")
                             i { text(actionName) }
                         }
-                        appendHTML().p {
+                        p {
                             text("Content: ")
                             i { text(content) }
                         }

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -5,8 +5,6 @@ import kotlinx.browser.window
 import kotlinx.dom.hasClass
 import kotlinx.html.b
 import kotlinx.html.code
-import kotlinx.html.div
-import kotlinx.html.dom.create
 import kotlinx.html.i
 import kotlinx.html.js.onClickFunction
 import kotlinx.html.p
@@ -268,18 +266,15 @@ public fun main() {
                                 {
                                     // This is run when writing to the clipboard is rejected (by Safari)
                                     // TODO(rymiel): pretty sure the editor API suffers the same issue, so this logic could be abstracted out and used there too
-                                    bulmaToast.toast(
-                                        document.create.div {
-                                            span { text("Short link (click to copy)") }
-                                            code { text(link) }
-                                            onClickFunction = {
-                                                window.navigator.clipboard.writeText(link).catch { error ->
-                                                    console.log(error) // Give up on trying to copy the thing
-                                                }
+                                    bulmaToast.toast(type = "is-warning") {
+                                        span { text("Short link (click to copy)") }
+                                        code { text(link) }
+                                        onClickFunction = {
+                                            window.navigator.clipboard.writeText(link).catch { error ->
+                                                console.log(error) // Give up on trying to copy the thing
                                             }
-                                        },
-                                        type = "is-warning"
-                                    )
+                                        }
+                                    }
                                 }
                             )
                         }
@@ -500,22 +495,19 @@ private fun checkClickEvents(target: EventTarget?, typesToCheck: Collection<Even
             } else {
                 val content = target.dataset[DATA_CLICK_EVENT_VALUE.camel] ?: ""
                 val actionName = clickAction.replace('_', ' ').replaceFirstChar(Char::uppercase)
-                bulmaToast.toast(
-                    document.create.div {
-                        p {
-                            b { text("Click Event") }
-                        }
-                        p {
-                            text("Action: ")
-                            i { text(actionName) }
-                        }
-                        p {
-                            text("Content: ")
-                            i { text(content) }
-                        }
-                    },
-                    type = "is-info"
-                )
+                bulmaToast.toast(type = "is-info") {
+                    p {
+                        b { text("Click Event") }
+                    }
+                    p {
+                        text("Action: ")
+                        i { text(actionName) }
+                    }
+                    p {
+                        text("Content: ")
+                        i { text(content) }
+                    }
+                }
             }
         }
 

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -18,6 +18,7 @@ import net.kyori.adventure.webui.URL_API
 import net.kyori.adventure.webui.URL_EDITOR
 import net.kyori.adventure.webui.URL_EDITOR_INPUT
 import net.kyori.adventure.webui.URL_EDITOR_OUTPUT
+import net.kyori.adventure.webui.URL_MINI_SHORTEN
 import net.kyori.adventure.webui.URL_MINI_TO_HTML
 import net.kyori.adventure.webui.URL_MINI_TO_JSON
 import net.kyori.adventure.webui.URL_MINI_TO_TREE
@@ -264,6 +265,16 @@ public fun main() {
                     window.navigator.clipboard.writeText(link).then {
                         bulmaToast.toast("Shareable link copied to clipboard!")
                     }
+                }
+            )
+            // CLIPBOARD
+            document.getElementById("temporary-short-link-share-button")!!.addEventListener(
+                "click",
+                {
+                    window.postPacket(
+                        "$URL_API$URL_MINI_SHORTEN",
+                        Combined(miniMessage = input.value, placeholders = readPlaceholders())
+                    ).then { response -> response.text().then { text -> console.log(text) } }
                 }
             )
             document.getElementById("copy-button")!!.addEventListener(

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -244,8 +244,8 @@ public fun main() {
                 }
             )
 
-            // CLIPBOARD
-            document.getElementById("link-share-button")!!.addEventListener(
+            // SHARING
+            document.getElementById("full-link-share-button")!!.addEventListener(
                 "click",
                 {
                     val inputValue = encodeURIComponent(input.value)
@@ -267,8 +267,7 @@ public fun main() {
                     }
                 }
             )
-            // CLIPBOARD
-            document.getElementById("temporary-short-link-share-button")!!.addEventListener(
+            document.getElementById("short-link-share-button")!!.addEventListener(
                 "click",
                 {
                     bytebinStore(Combined(miniMessage = input.value, placeholders = readPlaceholders()))
@@ -276,6 +275,17 @@ public fun main() {
                         .then { bulmaToast.toast("Shareable short link copied to clipboard!") }
                 }
             )
+            // Roll up the share dropdown after making a choice
+            document.getElementsByClassName("share-button").asList().forEach { element ->
+                element.addEventListener(
+                    "click",
+                    {
+                        element.closest(".dropdown")!!.classList.toggle("is-active")
+                    }
+                )
+            }
+
+            // CLIPBOARD
             document.getElementById("copy-button")!!.addEventListener(
                 "click",
                 {

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -519,11 +519,15 @@ private fun checkClickEvents(target: EventTarget?, typesToCheck: Collection<Even
             if (insertion == null) {
                 typesToCheck + EventType.INSERTION
             } else {
-                // TODO: match the HTML builder above?
-                bulmaToast.toast(
-                    "<p><b>Insertion</b></p><p>Content: <i>$insertion</i></p>",
-                    type = "is-info"
-                )
+                bulmaToast.toast(type = "is-info") {
+                    p {
+                        b { text("Insertion") }
+                    }
+                    p {
+                        text("Content: ")
+                        i { text(insertion) }
+                    }
+                }
             }
         }
 

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -4,11 +4,8 @@ import kotlinx.browser.document
 import kotlinx.browser.window
 import kotlinx.dom.hasClass
 import kotlinx.html.b
-import kotlinx.html.code
 import kotlinx.html.i
-import kotlinx.html.js.onClickFunction
 import kotlinx.html.p
-import kotlinx.html.span
 import kotlinx.serialization.encodeToString
 import net.kyori.adventure.webui.COMPONENT_CLASS
 import net.kyori.adventure.webui.DATA_CLICK_EVENT_ACTION
@@ -265,16 +262,7 @@ public fun main() {
                                 { bulmaToast.toast("Shareable short link copied to clipboard!") },
                                 {
                                     // This is run when writing to the clipboard is rejected (by Safari)
-                                    // TODO(rymiel): pretty sure the editor API suffers the same issue, so this logic could be abstracted out and used there too
-                                    bulmaToast.toast(type = "is-warning") {
-                                        span { text("Short link (click to copy)") }
-                                        code { text(link) }
-                                        onClickFunction = {
-                                            window.navigator.clipboard.writeText(link).catch { error ->
-                                                console.log(error) // Give up on trying to copy the thing
-                                            }
-                                        }
-                                    }
+                                    createCopyModal("Short link generated", link)
                                 }
                             )
                         }
@@ -283,9 +271,7 @@ public fun main() {
             // Roll up the share dropdown after making a choice
             /*
             TODO(rymiel): Perhaps the dropdown could stay open when the "short link" option is selected, instead turning
-              into a loading wheel, then the dropdown can close once that loading is done. Then, in the Safari case, when
-              writing to the clipboard is rejected, the link and it's "click to copy" can appear in that same dropdown
-              while it's still open, instead of in a toast somewhere else on the screen.
+              into a loading wheel, then the dropdown can close once that loading is done.
              */
             document.getElementsByClassName("share-button").asList().forEach { element ->
                 element.addEventListener(

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -363,6 +363,21 @@ public fun main() {
                 }
             )
 
+            // DROPDOWNS
+            document.getElementsByClassName("dropdown-trigger").asList().forEach { element ->
+                element.addEventListener(
+                    "click",
+                    {
+                        if (element.classList.contains("swatch-trigger")) {
+                            // This should hopefully make it so any text selected before pressing the color dropdown should stay visually selected
+                            val inputBox = document.getElementById("input")!!.unsafeCast<HTMLTextAreaElement>()
+                            inputBox.focus()
+                        }
+                        element.parentElement!!.classList.toggle("is-active")
+                    }
+                )
+            }
+
             installHoverManager()
             installStyleButtons()
         }

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -372,8 +372,9 @@ private fun onWebsocketReady() {
     val inputBox = document.getElementById("input")!!.unsafeCast<HTMLTextAreaElement>()
 
     if (!isInEditorMode) {
-        if (urlParams.has(PARAM_SHORT_LINK)) {
-            restoreFromShortLink(urlParams, inputBox, webSocket).then { parse() }
+        val shortCode = urlParams.get(PARAM_SHORT_LINK)
+        if (shortCode != null) {
+            restoreFromShortLink(shortCode, inputBox, webSocket).then { parse() }
         } else {
             urlParams.getFromParamsOrLocalStorage(PARAM_INPUT)?.also { inputString ->
                 inputBox.value = inputString

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -278,7 +278,7 @@ public fun main() {
                                                 }
                                             }
                                         },
-                                        "is-warning"
+                                        type = "is-warning"
                                     )
                                 }
                             )
@@ -286,6 +286,12 @@ public fun main() {
                 }
             )
             // Roll up the share dropdown after making a choice
+            /*
+            TODO(rymiel): Perhaps the dropdown could stay open when the "short link" option is selected, instead turning
+              into a loading wheel, then the dropdown can close once that loading is done. Then, in the Safari case, when
+              writing to the clipboard is rejected, the link and it's "click to copy" can appear in that same dropdown
+              while it's still open, instead of in a toast somewhere else on the screen.
+             */
             document.getElementsByClassName("share-button").asList().forEach { element ->
                 element.addEventListener(
                     "click",
@@ -521,6 +527,7 @@ private fun checkClickEvents(target: EventTarget?, typesToCheck: Collection<Even
             if (insertion == null) {
                 typesToCheck + EventType.INSERTION
             } else {
+                // TODO: match the HTML builder above?
                 bulmaToast.toast(
                     "<p><b>Insertion</b></p><p>Content: <i>$insertion</i></p>",
                     type = "is-info"

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Mode.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Mode.kt
@@ -19,7 +19,7 @@ public enum class Mode {
         /** A collection of all modes. */
         public val MODES: Collection<Mode> = values().asList()
 
-        private val DEFAULT: Mode = CHAT_CLOSED
+        public val DEFAULT: Mode = CHAT_CLOSED
         private val INDEX: Map<String, Mode> = MODES.associateBy { mode -> mode.name }
 
         /** Gets a mode from [string], returning [CHAT_CLOSED] as a default. */

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/PersistentStorage.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/PersistentStorage.kt
@@ -1,6 +1,7 @@
 package net.kyori.adventure.webui.js
 
 import kotlinx.browser.window
+import net.kyori.adventure.webui.websocket.Combined
 import org.w3c.dom.get
 import org.w3c.dom.url.URLSearchParams
 
@@ -15,6 +16,21 @@ public fun URLSearchParams.getFromParamsOrLocalStorage(key: String): String? {
         window.localStorage[key]?.also { stored ->
             println("STORED $key: $stored")
             return stored
+        }
+    }
+    return null
+}
+
+/** Fetches an input passed through a Combined if it is storing one, otherwise tries to use local storage */
+public fun <T> Combined?.getFromCombinedOrLocalStorage(key: String, method: (Combined) -> T?, mapping: (String) -> T = { it.unsafeCast<T>() }): T? {
+    val shared = if (this != null) method.invoke(this) else null
+    if (shared != null) {
+        println("SHARED $key: $shared")
+        return shared
+    } else {
+        window.localStorage[key]?.also { stored ->
+            println("STORED $key: $stored")
+            return mapping.invoke(stored)
         }
     }
     return null

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/StyleButtons.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/StyleButtons.kt
@@ -7,7 +7,6 @@ import org.w3c.dom.HTMLButtonElement
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.HTMLTextAreaElement
-import org.w3c.dom.asList
 
 // https://iro.js.org/colorPicker_api.html
 private external interface ColorPicker {
@@ -66,18 +65,6 @@ public fun installStyleButtons() {
             "click",
             {
                 handleStyleButton(inputBox, tag)
-            }
-        )
-    }
-
-    // TODO(rymiel): move this thing out of this file as it handles *all* dropdowns, not just the style button ones
-    document.getElementsByClassName("dropdown-trigger").asList().forEach { element ->
-        element.addEventListener(
-            "click",
-            {
-                // This should hopefully make it so any text selected before pressing the color dropdown should stay visually selected
-                inputBox.focus()
-                element.parentElement!!.classList.toggle("is-active")
             }
         )
     }

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/StyleButtons.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/StyleButtons.kt
@@ -70,6 +70,7 @@ public fun installStyleButtons() {
         )
     }
 
+    // TODO(rymiel): move this thing out of this file as it handles *all* dropdowns, not just the style button ones
     document.getElementsByClassName("dropdown-trigger").asList().forEach { element ->
         element.addEventListener(
             "click",

--- a/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/MiniMessage.kt
+++ b/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/MiniMessage.kt
@@ -11,6 +11,7 @@ import io.ktor.http.content.resources
 import io.ktor.http.content.static
 import io.ktor.request.receiveText
 import io.ktor.response.respondText
+import io.ktor.routing.get
 import io.ktor.routing.post
 import io.ktor.routing.route
 import io.ktor.routing.routing
@@ -177,6 +178,17 @@ public fun Application.miniMessage() {
                     call.respondText(code)
                 } else {
                     call.response.status(HttpStatusCode.InternalServerError)
+                }
+            }
+
+            get(URL_MINI_SHORTEN) {
+                val code = call.parameters["code"]
+                val structure = BytebinStorage.bytebinLoad(code ?: return@get)
+                if (structure != null) {
+                    // Pretty sure this is pointlessly decoding from json and then re-encoding to the same thing
+                    call.respondText(Serializers.json.encodeToString(structure))
+                } else {
+                    call.response.status(HttpStatusCode.NotFound)
                 }
             }
 

--- a/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/storage/BytebinStorage.kt
+++ b/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/storage/BytebinStorage.kt
@@ -1,17 +1,19 @@
 package net.kyori.adventure.webui.jvm.minimessage.storage
 
 import io.ktor.client.HttpClient
+import io.ktor.client.request.get
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.readText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import kotlinx.serialization.encodeToString
 import net.kyori.adventure.webui.Serializers
+import net.kyori.adventure.webui.tryDecodeFromString
 import net.kyori.adventure.webui.websocket.Combined
 
 public object BytebinStorage {
-    /** The Bytebin instance being used */
     private const val BYTEBIN_INSTANCE: String = "https://bytebin.lucko.me"
 
     private val client = HttpClient()
@@ -27,6 +29,19 @@ public object BytebinStorage {
         }
         if (response.status.isSuccess()) {
             return response.headers[HttpHeaders.Location]
+        }
+        return null
+    }
+
+    public suspend fun bytebinLoad(code: String): Combined? {
+        val response: HttpResponse = client.get("$BYTEBIN_INSTANCE/$code") {
+            headers {
+                append(HttpHeaders.Accept, "application/json")
+                append(HttpHeaders.UserAgent, "KyoriPowered/adventure-webui")
+            }
+        }
+        if (response.status.isSuccess()) {
+            return Serializers.json.tryDecodeFromString(response.readText())
         }
         return null
     }

--- a/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/storage/BytebinStorage.kt
+++ b/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/storage/BytebinStorage.kt
@@ -1,0 +1,33 @@
+package net.kyori.adventure.webui.jvm.minimessage.storage
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpHeaders
+import io.ktor.http.isSuccess
+import kotlinx.serialization.encodeToString
+import net.kyori.adventure.webui.Serializers
+import net.kyori.adventure.webui.websocket.Combined
+
+public object BytebinStorage {
+    /** The Bytebin instance being used */
+    private const val BYTEBIN_INSTANCE: String = "https://bytebin.lucko.me"
+
+    private val client = HttpClient()
+
+    public suspend fun bytebinStore(payload: Combined): String? {
+        val response: HttpResponse = client.post("$BYTEBIN_INSTANCE/post") {
+            headers {
+                append(HttpHeaders.ContentType, "application/json")
+                append(HttpHeaders.Accept, "application/json")
+                append(HttpHeaders.UserAgent, "KyoriPowered/adventure-webui")
+            }
+            body = Serializers.json.encodeToString(payload)
+        }
+        if (response.status.isSuccess()) {
+            return response.headers[HttpHeaders.Location]
+        }
+        return null
+    }
+}


### PR DESCRIPTION
WIP! has lots of TODOs

Partially implements #51

Allow for sharing short links for saved input, using [bytebin](https://github.com/lucko/bytebin) as longer term storage.  
Due to indecisiveness, I've implemented the bytebin-related logic on both client- and server-side, ~~with just a const bool to choose. In server-side mode, the server essentially acts as a direct proxy to bytebin as it does almost no additional logic on its end, so the web requests make sense to put on the client instead. Additionally, I needed to add an http client as a dependency on the jvm side for this one single purpose.
However, there might be some merit to the more "abstract" implementation of it being on the server, perhaps making it easier to swap it out or something, with better access control etc.~~

Since bytebin doesn't have infinite storage, these short-links will eventually expire, unlike full links, which should have all the data in it and should theoretically continue to work, as long as the site itself is up. This distinction will need to be made in the frontend, but there is 0 frontend work so far anyway.

This added logic could also be used to supercharge the editor API, making it last longer for example

Poorly written, duplicate-heavy code ahead!!