### PR TITLE
fix: Properly reload background when loading link with server list mode

### DIFF
--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Background.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Background.kt
@@ -18,16 +18,16 @@ public var currentBackground: String? = null
     }
 
 public fun updateBackground() {
-    val bg = currentBackground ?: return
-    if (!validBackgrounds.contains(currentBackground)) return
-    window.localStorage[PARAM_BACKGROUND] = bg
-    settingBackground.value = bg
     if (currentMode == Mode.SERVER_LIST) {
         // Remove the current background if we are switching to "server list"
         // as it has a black background that is otherwise overridden
         outputPane.style.removeProperty("background-image")
     } else {
         // Otherwise, try to put back the background from before
+        val bg = currentBackground ?: return
+        if (!validBackgrounds.contains(currentBackground)) return
+        window.localStorage[PARAM_BACKGROUND] = bg
+        settingBackground.value = bg
         outputPane.style.backgroundImage = "url(\"img/$bg.jpg\")"
     }
 }

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -203,7 +203,6 @@ public fun mainLoaded() {
             "click",
             {
                 setMode(mode)
-                updateBackground()
                 parse()
             }
         )
@@ -399,6 +398,8 @@ public fun setMode(newMode: Mode) {
             outputPane.classList.remove(mode.className)
         }
     }
+
+    updateBackground()
 }
 
 private fun readPlaceholders(): Placeholders {


### PR DESCRIPTION
Consider the following link: <https://webui.adventure.kyori.net/?x=JDPtIK5fM4>
It is in server list mode but doesn't set the proper background for it, this PR fixes that