### PR TITLE
fix: use correct variable to disallow tooltip to go off bottom of screen

### DIFF
--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/HoverManager.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/HoverManager.kt
@@ -62,12 +62,12 @@ public fun installHoverManager() {
                 if (top < 0) {
                     top += hoverHeight + 47
                 }
-                // Don't go off the top of the screen
             } else if (top < 0) {
+                // Don't go off the top of the screen
                 top = 0
-                // Don't go off the bottom of the screen
             } else if (top + hoverHeight > windowHeight) {
-                top = windowHeight - windowWidth
+                // Don't go off the bottom of the screen
+                top = windowHeight - hoverHeight
             }
 
             hoverTooltip.style.top = "${top}px"


### PR DESCRIPTION
Fixes #113 

just a typo using the wrong variable, makes no sense to subtract the *width* when modifying the height.

Also moves comments around because their indentation made them appear to apply to the wrong section