### PR TITLE
Add clickable swatches for each of the 16 "named" colors

### DIFF
--- a/src/commonMain/resources/web/css/style.css
+++ b/src/commonMain/resources/web/css/style.css
@@ -239,9 +239,24 @@ html {
     flex-shrink: 0;
     margin-left: 4px;
 }
-.swatch {
+#named-swatch {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(8, 1fr);
+    width: 6rem;
+    padding-right: 1rem;
+}
+#named-swatch > .swatch {
+    cursor: pointer;
+    margin-bottom: 2px;
+}
+.swatch-l {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
+}
+.swatch-r {
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
 }
 input.placeholder-key:invalid {
     border: 2px red solid;

--- a/src/commonMain/resources/web/css/style.css
+++ b/src/commonMain/resources/web/css/style.css
@@ -258,6 +258,10 @@ html {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
 }
+#palette-dropdown-menu {
+    left: -4rem;
+    right: auto;
+}
 input.placeholder-key:invalid {
     border: 2px red solid;
 }

--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -122,7 +122,7 @@
             <div class="is-horizontal is-flex">
               <label for="input">Input: </label>
               <div class="is-flex ml-auto">
-                <div class="dropdown">
+                <div class="dropdown is-right">
                   <div class="dropdown-trigger swatch-trigger">
                     <button class="button" aria-haspopup="true" aria-controls="palette-dropdown-menu">
                       <span class="icon is-small">
@@ -133,11 +133,32 @@
                   <div class="dropdown-menu" id="palette-dropdown-menu" role="menu">
                     <div class="dropdown-content">
                       <div class="dropdown-item">
-                        <div id="picker"></div>
+                        <div class="is-flex">
+                          <div id="named-swatch" class="is-flex-grow-1 is-hidden-mobile">
+                            <div class="swatch swatch-l" data-color="#000000" style="background: #000000;" title="Black"></div>
+                            <div class="swatch swatch-r" data-color="#555555" style="background: #555555;" title="Dark Gray"></div>
+                            <div class="swatch swatch-l" data-color="#0000aa" style="background: #0000aa;" title="Dark Blue"></div>
+                            <div class="swatch swatch-r" data-color="#5555ff" style="background: #5555ff;" title="Blue"></div>
+                            <div class="swatch swatch-l" data-color="#00aa00" style="background: #00aa00;" title="Dark Green"></div>
+                            <div class="swatch swatch-r" data-color="#55ff55" style="background: #55ff55;" title="Green"></div>
+                            <div class="swatch swatch-l" data-color="#00aaaa" style="background: #00aaaa;" title="Dark Aqua"></div>
+                            <div class="swatch swatch-r" data-color="#55ffff" style="background: #55ffff;" title="Aqua"></div>
+                            <div class="swatch swatch-l" data-color="#aa0000" style="background: #aa0000;" title="Dark Red"></div>
+                            <div class="swatch swatch-r" data-color="#ff5555" style="background: #ff5555;" title="Red"></div>
+                            <div class="swatch swatch-l" data-color="#aa00aa" style="background: #aa00aa;" title="Dark Purple"></div>
+                            <div class="swatch swatch-r" data-color="#ff55ff" style="background: #ff55ff;" title="Light Purple"></div>
+                            <div class="swatch swatch-l" data-color="#ffaa00" style="background: #ffaa00;" title="Gold"></div>
+                            <div class="swatch swatch-r" data-color="#ffff55" style="background: #ffff55;" title="Yellow"></div>
+                            <div class="swatch swatch-l" data-color="#aaaaaa" style="background: #aaaaaa;" title="Gray"></div>
+                            <div class="swatch swatch-r" data-color="#ffffff" style="background: #ffffff;" title="White"></div>
+                          </div>
+                          <div id="picker"></div>
+                        </div>
                       </div>
+                      <hr class="dropdown-divider">
                       <div class="dropdown-item is-flex">
                         <div class="field has-addons is-flex-grow-1">
-                          <div id="preview-swatch" class="swatch is-flex-grow-1" style="background: #ffffff;"></div>
+                          <div id="preview-swatch" class="swatch swatch-l is-flex-grow-1" style="background: #ffffff;"></div>
                           <div class="control">
                             <input id="preview-hex" class="input is-family-monospace has-text-centered" type="text" size="7" value="#ffffff">
                           </div>

--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -122,7 +122,7 @@
             <div class="is-horizontal is-flex">
               <label for="input">Input: </label>
               <div class="is-flex ml-auto">
-                <div class="dropdown is-right">
+                <div class="dropdown">
                   <div class="dropdown-trigger swatch-trigger">
                     <button class="button" aria-haspopup="true" aria-controls="palette-dropdown-menu">
                       <span class="icon is-small">

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/StyleButtons.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/StyleButtons.kt
@@ -7,6 +7,8 @@ import org.w3c.dom.HTMLButtonElement
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.HTMLTextAreaElement
+import org.w3c.dom.asList
+import org.w3c.dom.get
 
 // https://iro.js.org/colorPicker_api.html
 private external interface ColorPicker {
@@ -105,6 +107,17 @@ public fun installStyleButtons() {
         }
     )
 
+    val namedSwatch = document.getElementById("named-swatch")!!.unsafeCast<HTMLDivElement>()
+    namedSwatch.children.asList().forEach { swatch ->
+        val swatchElement = swatch.unsafeCast<HTMLDivElement>()
+        swatchElement.addEventListener("click", {
+            colorPicker.color.hexString = swatchElement.dataset["color"].orEmpty()
+            // Clicking (on a swatch) takes away focus from the editor, put it back so the user still sees
+            // their selection and knows what they're about to modify.
+            inputBox.focus()
+        })
+    }
+
     val useColorButton = document.getElementById("use-color")!!.unsafeCast<HTMLButtonElement>()
     useColorButton.addEventListener(
         "click",
@@ -172,6 +185,13 @@ private fun handleStyleButton(inputBox: HTMLTextAreaElement, tag: StyleTag) {
 
     // This makes sure the websocket stuff is actually fired so the preview stays in sync.
     inputBox.dispatchEvent(CustomEvent("change", CustomEventInit(bubbles = true, cancelable = true)))
+
+    /*
+     TODO(rymiel): This focus() is problematic on mobile, as it'll most likely throw up the keyboard all of a sudden
+       which takes up a bunch of the screen. This isn't strictly a concern on the other focus() call above, as the
+       color swatches are hidden on mobile anyway, but still something to probably disable when an on-screen keyboard
+       is used
+     */
     inputBox.focus()
     inputBox.setSelectionRange(newSelStart, newSelEnd)
 }


### PR DESCRIPTION
Closes #118. Was originally planned as part of #56 but didn't make it.

Note that this whole addition is disabled on mobile because of width concerns.


https://user-images.githubusercontent.com/53803019/173894990-85113e4a-9a04-4aa5-a4bf-2c9c81663121.mp4

