### PR TITLE
Build info endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,7 +106,13 @@ tasks.getByName<AbstractCopyTask>("jvmProcessResources") {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 
     filesMatching("application.conf") {
-        expand("jsScriptFile" to "${rootProject.name}.js")
+        expand(
+            "jsScriptFile" to "${rootProject.name}.js",
+            "miniMessageVersion" to project.configurations.getByName("compileClasspath")
+                .resolvedConfiguration.resolvedArtifacts
+                .find { i -> i.name == "adventure-text-minimessage" }?.moduleVersion?.id?.version.orEmpty(),
+            "commitHash" to rootProject.extensions.findByType<IndraGitExtension>()!!.commit()?.name.orEmpty()
+        )
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,9 +108,7 @@ tasks.getByName<AbstractCopyTask>("jvmProcessResources") {
     filesMatching("application.conf") {
         expand(
             "jsScriptFile" to "${rootProject.name}.js",
-            "miniMessageVersion" to project.configurations.getByName("compileClasspath")
-                .resolvedConfiguration.resolvedArtifacts
-                .find { i -> i.name == "adventure-text-minimessage" }?.moduleVersion?.id?.version.orEmpty(),
+            "miniMessageVersion" to libs.adventure.minimessage.get().versionConstraint.requiredVersion,
             "commitHash" to rootProject.extensions.findByType<IndraGitExtension>()!!.commit()?.name.orEmpty()
         )
     }

--- a/src/commonMain/kotlin/net/kyori/adventure/webui/BuildInfo.kt
+++ b/src/commonMain/kotlin/net/kyori/adventure/webui/BuildInfo.kt
@@ -1,0 +1,11 @@
+package net.kyori.adventure.webui
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class BuildInfo(
+    public val startedAt: String,
+    public val version: String,
+    public val commit: String,
+    public val bytebinInstance: String
+)

--- a/src/commonMain/kotlin/net/kyori/adventure/webui/Constants.kt
+++ b/src/commonMain/kotlin/net/kyori/adventure/webui/Constants.kt
@@ -44,4 +44,3 @@ public const val URL_MINI_SHORTEN: String = "/mini-shorten"
 
 /** Path for getting the configuration of this WebUI instance */
 public const val URL_BUILD_INFO: String = "/build"
-

--- a/src/commonMain/kotlin/net/kyori/adventure/webui/Constants.kt
+++ b/src/commonMain/kotlin/net/kyori/adventure/webui/Constants.kt
@@ -41,3 +41,7 @@ public const val PARAM_EDITOR_TOKEN: String = "token"
 
 /** Path for getting a short link for a MiniMessage input. */
 public const val URL_MINI_SHORTEN: String = "/mini-shorten"
+
+/** Path for getting the configuration of this WebUI instance */
+public const val URL_BUILD_INFO: String = "/build"
+

--- a/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/MiniMessage.kt
+++ b/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/MiniMessage.kt
@@ -21,8 +21,10 @@ import net.kyori.adventure.text.minimessage.MiniMessage
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import net.kyori.adventure.webui.BuildInfo
 import net.kyori.adventure.webui.Serializers
 import net.kyori.adventure.webui.URL_API
+import net.kyori.adventure.webui.URL_BUILD_INFO
 import net.kyori.adventure.webui.URL_EDITOR
 import net.kyori.adventure.webui.URL_MINI_SHORTEN
 import net.kyori.adventure.webui.URL_MINI_TO_HTML
@@ -48,6 +50,9 @@ import net.kyori.adventure.webui.websocket.Packet
 import net.kyori.adventure.webui.websocket.ParseResult
 import net.kyori.adventure.webui.websocket.Placeholders
 import net.kyori.adventure.webui.websocket.Response
+import java.time.Instant
+
+private val startedAt = Instant.now()
 
 public val Placeholders?.tagResolver: TagResolver
     get() {
@@ -84,6 +89,8 @@ public fun Application.miniMessage() {
         component(FONT_RENDER_HOOK)
         component(TEXT_RENDER_HOOK, 500) // content needs to be set last
     }
+
+    BytebinStorage.BYTEBIN_INSTANCE = this.getConfigString("bytebinInstance")
 
     routing {
         // define static path to resources
@@ -190,6 +197,16 @@ public fun Application.miniMessage() {
                 } else {
                     call.response.status(HttpStatusCode.NotFound)
                 }
+            }
+
+            get(URL_BUILD_INFO) {
+                val info = BuildInfo(
+                    startedAt = startedAt.toString(),
+                    version = this@miniMessage.getConfigString("miniMessageVersion"),
+                    commit = this@miniMessage.getConfigString("commitHash"),
+                    bytebinInstance = BytebinStorage.BYTEBIN_INSTANCE,
+                )
+                call.respondText(Serializers.json.encodeToString(info))
             }
 
             route(URL_EDITOR) { installEditor() }

--- a/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/storage/BytebinStorage.kt
+++ b/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/storage/BytebinStorage.kt
@@ -15,7 +15,7 @@ import net.kyori.adventure.webui.tryDecodeFromString
 import net.kyori.adventure.webui.websocket.Combined
 
 public object BytebinStorage {
-    private const val BYTEBIN_INSTANCE: String = "https://bytebin.lucko.me"
+    public lateinit var BYTEBIN_INSTANCE: String
 
     private val client = HttpClient()
 

--- a/src/jvmMain/resources/application.conf
+++ b/src/jvmMain/resources/application.conf
@@ -12,5 +12,8 @@ ktor {
 
   config {
     jsScriptFile = "$jsScriptFile"
+    miniMessageVersion = "$miniMessageVersion"
+    commitHash = "$commitHash"
+    bytebinInstance = "https://bytebin.lucko.me"
   }
 }


### PR DESCRIPTION
Closes #16. Closes #109.

Adds the endpoint `/api/build`, which returns
* server start time,
* adventure-text-minimessage version,
* webui commit hash at build time, and
* configured bytebin URL (https://bytebin.lucko.me by default)

These are mostly set through application.conf. The client will check this build endpoint to determine what bytebin instance to use, then cache it for next time