### PR TITLE
Listen for when the websocket closes and display a warning

### DIFF
--- a/src/commonMain/resources/web/index.html
+++ b/src/commonMain/resources/web/index.html
@@ -228,6 +228,9 @@
           <div hidden id="hover-tooltip" class="mc-font"></div>
           <div class="column is-full is-flex is-flex-direction-column">
             <label for="output-pane">Output: </label>
+            <p hidden id="connection-lost-warning" class="has-text-danger is-size-4">
+              <span class="icon"><i class="fas fa-exclamation-triangle"></i></span> Your connection with the server has been lost, please reload the page.
+            </p>
             <div id="output-pane" class="is-flex is-flex-grow-1 is-flex-shrink-0">
               <div id="chat-entry-box">_</div>
               <div id="server-list-icon">

--- a/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
+++ b/src/jsMain/kotlin/net/kyori/adventure/webui/js/Main.kt
@@ -144,6 +144,9 @@ public fun mainLoaded() {
             WebSocket("wss://${window.location.host}$URL_API$URL_MINI_TO_HTML")
         }
     webSocket.onopen = { onWebsocketReady() }
+    webSocket.onclose = { onWebsocketClose() }
+    // A closed websocket will be handled by the above, but log the error to console for debugging sake
+    webSocket.onerror = { err -> console.log("Websocket error: $err") }
 
     // CORRECT HOME LINK
     document.getElementById("home-link")!!.unsafeCast<HTMLAnchorElement>().href = homeUrl
@@ -488,6 +491,16 @@ private fun onWebsocketReady() {
                 }
             }
         }
+}
+
+private fun onWebsocketClose() {
+    // We no longer have a working websocket connection, so any input changes would not go through. Display a little
+    // warning to the user and disable the input box to bring more attention to it, since changing the input would
+    // have no effect at this point anyway.
+    val warning = document.getElementById("connection-lost-warning")!!.unsafeCast<HTMLTextAreaElement>()
+    val inputBox = document.getElementById("input")!!.unsafeCast<HTMLTextAreaElement>()
+    warning.hidden = false
+    inputBox.disabled = true
 }
 
 private fun checkClickEvents(target: EventTarget?, typesToCheck: Collection<EventType>) {


### PR DESCRIPTION
This shouldn't normally happen, but if it does, previous the input would simply stop working. With this change, it displays a warning

It could also attempt to reconnect or something, but given that a websocket closure should *only* happen in weird cases, such as losing all internet connection, I have low confidence in a reconnect being successful at all. The user can simply manually do a reconnect by using the refresh button anyway