### PR TITLE
feat: Deploy docker images using Jib

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,10 @@ jobs:
           java-version: "${{ env.JAVA_VERSION }}"
       - name: "validate gradle wrapper"
         uses: "gradle/wrapper-validation-action@v1"
-      - name: "build for deployment"
+      - name: "build for production"
         uses: "gradle/gradle-build-action@v2"
         with:
-          arguments: "distTar"
+          arguments: "build"
       - name: "setup ssh"
         uses: webfactory/ssh-agent@v0.8.0
         with:
@@ -40,9 +40,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: "deploy docker"
+      - name: "publish / docker image"
+        run: ./gradlew jib
+      - name: "publish / deploy to production"
+        env:
+          DOCKER_HOST: "${{ secrets.DOCKER_HOST }}"
         run: |
           echo ${{ secrets.DOCKER_HOST_SSH_SIG }} > ~/.ssh/known_hosts
-          docker-compose build
-          docker-compose push
-          DOCKER_HOST="${{ secrets.DOCKER_HOST }}" docker stack deploy --with-registry-auth --compose-file=docker-compose.yml adventure-webui
+          docker stack deploy --with-registry-auth --compose-file=docker-compose.yml adventure-webui

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM adoptopenjdk/openjdk11:debian-slim
-
-WORKDIR /app
-
-COPY build/distributions/adventure-webui.tar /app/
-RUN tar -xvf /app/adventure-webui.tar
-RUN rm /app/adventure-webui.tar
-
-ENTRYPOINT ["sh", "/app/adventure-webui/bin/adventure-webui"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -137,6 +137,11 @@ jib {
     }
     container {
         setMainClass(application.mainClass)
+        labels.put(
+            "org.opencontainers.image.description",
+            """A Web UI for working with Adventure components. 
+            Built with Adventure ${libs.versions.adventure.get()}, from webui commit ${indraGit.commit()?.name ?: "<unknown>"}""",
+        )
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -136,7 +136,7 @@ jib {
         }
     }
     container {
-        mainClass = application.mainClass.get()
+        setMainClass(application.mainClass)
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,6 @@ version: '3.7'
 services:
   webui:
     image: ghcr.io/kyoripowered/adventure-webui/webui:latest
-    build:
-      context: .
-      dockerfile: Dockerfile
     labels:
       - "traefik.enable=true"
       - "traefik.http.services.adventure-webui.loadbalancer.server.port=8080"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ ktor = "2.3.1"
 
 [plugins]
 indra-git = { id = "net.kyori.indra.git", version = "3.1.1" }
+jib = { id = "com.google.cloud.tools.jib", version = "3.3.2" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}
 spotless = { id = "com.diffplug.spotless", version = "6.19.0" }

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ This will create a server running at `http://localhost:8080`.
 
 For production usage, simply remove the development flag from the run task.
 Alternatively, the `distribution` tasks (for example, `distTar`) can be used to create or install archives that contain scripts to run the server.
-A [Dockerfile](Dockerfile) has also been provided which can be used to create a Docker image.
+A Docker image is published at `ghrc.io/KyoriPowered/adventure-webui/webui`, or for local builds using `./gradlew jibBuildTar` (or `./gradlew jibDockerBuild` to push it to your local docker instance)
 
 ### Contributing
 


### PR DESCRIPTION
This replaces the old manual Dockerfile, which had implicit dependencies on certain gradle tasks being run already and resulted in another spot to configure options.

[Jib](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin) unifies build and runtime configuration within one file, and is intended to build more disk-efficient docker images as well.