### PR TITLE
Show pointer cursor for clickable components

### DIFF
--- a/src/commonMain/resources/web/css/style.css
+++ b/src/commonMain/resources/web/css/style.css
@@ -268,6 +268,9 @@ input.placeholder-key:invalid {
 #placeholder-tip {
     display: none;
 }
+[data-click-event-action] {
+    cursor: pointer;
+}
 @media (prefers-color-scheme: light) {
     body {
         background-color: #E6E6E6;


### PR DESCRIPTION
This PR adds a CSS rule that changes the cursor to a pointer when the user mouses over a clickable component in the preview. This may help to better indicate that a component is indeed clickable and that the syntax the user has typed is accurate.