### PR TITLE
Always position bottom left corner behind the preview

### DIFF
--- a/src/commonMain/resources/web/css/style.css
+++ b/src/commonMain/resources/web/css/style.css
@@ -40,6 +40,7 @@
 #output-pane {
     background-image: url("../img/grass.jpg");
     background-size: cover;
+    background-position: bottom left;
 }
 #output-pane #server-list-icon,
 #output-pane #server-list-header {


### PR DESCRIPTION
This PR makes sure that whatever is important in the selected background (like desert, water, grass) is always behind the chat preview. On smaller browsers it can happen that it's not the water but the mountain that's behind the chat window, rendering the selected image useless (e.g. for contrast checks).