### PR TITLE
fix: Correct text shadow colour

### DIFF
--- a/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/hook/StandardRenderHooks.kt
+++ b/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/hook/StandardRenderHooks.kt
@@ -57,13 +57,10 @@ public val TEXT_COLOR_RENDER_HOOK: ComponentRenderHook = { component ->
     component.color()?.let { color ->
         addStyle("color: ${color.asHexString()}")
 
-        val hsv = color.asHSV()
-        val h = (hsv.h() * 360.0f).toInt()
-        val s = (hsv.s() * 100.0f).toInt()
-        val l = ((hsv.v() * 100.0f) / 4f).toInt()
-
-        // text shadows use hsl with lightness divided by 4 and floored
-        addStyle("text-shadow: 3px 3px hsl($h, $s%, $l%)")
+        val r = color.red() / 4
+        val g = color.green() / 4
+        val b = color.blue() / 4
+        addStyle("text-shadow: 3px 3px rgb($r, $g, $b)")
     }
 
     true

--- a/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/hook/StandardRenderHooks.kt
+++ b/src/jvmMain/kotlin/net/kyori/adventure/webui/jvm/minimessage/hook/StandardRenderHooks.kt
@@ -57,9 +57,9 @@ public val TEXT_COLOR_RENDER_HOOK: ComponentRenderHook = { component ->
     component.color()?.let { color ->
         addStyle("color: ${color.asHexString()}")
 
-        val r = color.red() / 4
-        val g = color.green() / 4
-        val b = color.blue() / 4
+        val r = color.red() / 4.0
+        val g = color.green() / 4.0
+        val b = color.blue() / 4.0
         addStyle("text-shadow: 3px 3px rgb($r, $g, $b)")
     }
 


### PR DESCRIPTION
The colour selected for text shadows doesn't currently match the game, and is often way too bright. For example, `<#ffff00>example`, in-game and in the viewer:
![Screenshot 2024-04-01 at 20 59 57](https://github.com/KyoriPowered/adventure-webui/assets/35287819/db6c1188-1208-4c50-8056-b9541e7b63c5)
![Screenshot 2024-04-01 at 21 00 13](https://github.com/KyoriPowered/adventure-webui/assets/35287819/073c05a2-1fd6-41bf-9c03-e34367be9284)

This PR uses the same logic as the game (see `net.minecraft.client.gui.Font.StringRenderOutput#dimFactor`).